### PR TITLE
Package upgrade eslint 9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,34 +1,26 @@
 {
     "name": "eslint-plugin-sequence",
-    "version": "0.6.1",
+    "version": "0.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "eslint-plugin-sequence",
-            "version": "0.6.1",
+            "version": "0.7.0",
             "license": "ISC",
             "dependencies": {
                 "module-alias": "^2.2.3"
             },
             "devDependencies": {
-                "@types/eslint": "^8.44.6",
-                "@types/module-alias": "^2.0.3",
-                "@types/node": "^20.8.10",
-                "@typescript-eslint/eslint-plugin": "^6.9.1",
-                "@typescript-eslint/parser": "^6.9.1",
-                "eslint": "^8.53.0",
-                "ts-node": "^10.9.1",
-                "typescript": "^4.5.4"
-            }
-        },
-        "node_modules/@aashutoshrathi/word-wrap": {
-            "version": "1.2.6",
-            "resolved": "https://registry.npmjs.org/@aashutoshrathi/word-wrap/-/word-wrap-1.2.6.tgz",
-            "integrity": "sha512-1Yjs2SvM8TflER/OD3cOjhWWOZb58A2t7wpE2S9XfBYTiIl+XFhQG2bjy4Pu1I+EAlCNUzRDYDdFwFYUKvXcIA==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
+                "@eslint/js": "^9.16.0",
+                "@types/eslint": "^9.6.1",
+                "@types/module-alias": "^2.0.4",
+                "@types/node": "^22.10.2",
+                "@typescript-eslint/parser": "^8.18.0",
+                "@typescript-eslint/rule-tester": "^8.18.0",
+                "ts-node": "^10.9.2",
+                "typescript": "^5.7.2",
+                "typescript-eslint": "^8.18.0"
             }
         },
         "node_modules/@cspotcode/source-map-support": {
@@ -36,6 +28,7 @@
             "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
             "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/trace-mapping": "0.3.9"
             },
@@ -44,39 +37,102 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.0.tgz",
-            "integrity": "sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==",
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
+            "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "eslint-visitor-keys": "^3.3.0"
+                "eslint-visitor-keys": "^3.4.3"
             },
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
             },
             "peerDependencies": {
                 "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.10.0",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
-            "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
+            "version": "4.12.1",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.12.1.tgz",
+            "integrity": "sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
             }
         },
-        "node_modules/@eslint/eslintrc": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
-            "integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
+        "node_modules/@eslint/config-array": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
+            "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
             "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@eslint/object-schema": "^2.1.5",
+                "debug": "^4.3.1",
+                "minimatch": "^3.1.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/config-array/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/@eslint/config-array/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
+            },
+            "engines": {
+                "node": "*"
+            }
+        },
+        "node_modules/@eslint/core": {
+            "version": "0.9.1",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
+            "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@types/json-schema": "^7.0.15"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/eslintrc": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
+            "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ajv": "^6.12.4",
                 "debug": "^4.3.2",
-                "espree": "^9.6.0",
-                "globals": "^13.19.0",
+                "espree": "^10.0.1",
+                "globals": "^14.0.0",
                 "ignore": "^5.2.0",
                 "import-fresh": "^3.2.1",
                 "js-yaml": "^4.1.0",
@@ -84,33 +140,112 @@
                 "strip-json-comments": "^3.1.1"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/@eslint/js": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.53.0.tgz",
-            "integrity": "sha512-Kn7K8dx/5U6+cT1yEhpX1w4PCSg0M+XyRILPgvwcEBjerFWCwQj5sbr3/VmxqV0JGHCBCzyd6LxypEuehypY1w==",
+        "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
-            "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+            "license": "MIT",
+            "peer": true,
+            "dependencies": {
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
             }
         },
-        "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.13",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
-            "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
+        "node_modules/@eslint/eslintrc/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
             "dev": true,
+            "license": "ISC",
+            "peer": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^2.0.1",
-                "debug": "^4.1.1",
-                "minimatch": "^3.0.5"
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
-                "node": ">=10.10.0"
+                "node": "*"
+            }
+        },
+        "node_modules/@eslint/js": {
+            "version": "9.16.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.16.0.tgz",
+            "integrity": "sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/object-schema": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
+            "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@eslint/plugin-kit": {
+            "version": "0.2.4",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
+            "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "levn": "^0.4.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
+        "node_modules/@humanfs/core": {
+            "version": "0.19.1",
+            "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
+            "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node": {
+            "version": "0.16.6",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
+            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "dependencies": {
+                "@humanfs/core": "^0.19.1",
+                "@humanwhocodes/retry": "^0.3.0"
+            },
+            "engines": {
+                "node": ">=18.18.0"
+            }
+        },
+        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
+            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -118,6 +253,8 @@
             "resolved": "https://registry.npmjs.org/@humanwhocodes/module-importer/-/module-importer-1.0.1.tgz",
             "integrity": "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA==",
             "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=12.22"
             },
@@ -126,32 +263,44 @@
                 "url": "https://github.com/sponsors/nzakas"
             }
         },
-        "node_modules/@humanwhocodes/object-schema": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
-            "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
-            "dev": true
+        "node_modules/@humanwhocodes/retry": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
+            "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": ">=18.18"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/nzakas"
+            }
         },
         "node_modules/@jridgewell/resolve-uri": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.1.tgz",
-            "integrity": "sha512-dSYZh7HhCDtCKm4QakX0xFpsRDqjjtZf/kjI/v3T3Nwt5r8/qz/M19F9ySyOqU94SXBmeG9ttTul+YnR4LOxFA==",
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+            "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6.0.0"
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.4.15",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-            "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg==",
-            "dev": true
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@jridgewell/trace-mapping": {
             "version": "0.3.9",
             "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
             "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.0.3",
                 "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -162,6 +311,7 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
             "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "2.0.5",
                 "run-parallel": "^1.1.9"
@@ -175,6 +325,7 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
             "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
@@ -184,6 +335,7 @@
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
             "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
@@ -193,33 +345,37 @@
             }
         },
         "node_modules/@tsconfig/node10": {
-            "version": "1.0.9",
-            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-            "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-            "dev": true
+            "version": "1.0.11",
+            "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.11.tgz",
+            "integrity": "sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@tsconfig/node12": {
             "version": "1.0.11",
             "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
             "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@tsconfig/node14": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
             "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@tsconfig/node16": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.4.tgz",
             "integrity": "sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/eslint": {
-            "version": "8.56.12",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.56.12.tgz",
-            "integrity": "sha512-03ruubjWyOHlmljCVoxSuNDdmfZDzsrrz0P2LeJsOXr+ZwFQ+0yQIwNCwt/GYhV7Z31fgtXJTAEs+FYlEL851g==",
+            "version": "9.6.1",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+            "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -228,112 +384,128 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.4.tgz",
-            "integrity": "sha512-2JwWnHK9H+wUZNorf2Zr6ves96WHoWDJIftkcxPKsS7Djta6Zu519LarhRNljPXkpsZR2ZMwNCPeW7omW07BJw==",
-            "dev": true
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
+            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.14",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
-            "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
-            "dev": true
+            "version": "7.0.15",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
+            "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/module-alias": {
-            "version": "2.0.3",
-            "resolved": "https://registry.npmjs.org/@types/module-alias/-/module-alias-2.0.3.tgz",
-            "integrity": "sha512-P4nKOHbLwvzpPWA5rqJXEAvkIePPb4fNMaEzVU3qZp53NEg2buF9KaudA7BfduUd0b/M1+cM9w050WJ+sDHktw==",
-            "dev": true
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/@types/module-alias/-/module-alias-2.0.4.tgz",
+            "integrity": "sha512-5+G/QXO/DvHZw60FjvbDzO4JmlD/nG5m2/vVGt25VN1eeP3w2bCoks1Wa7VuptMPM1TxJdx6RjO70N9Fw0nZPA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "20.8.10",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.10.tgz",
-            "integrity": "sha512-TlgT8JntpcbmKUFzjhsyhGfP2fsiz1Mv56im6enJ905xG1DAYesxJaeSbGqQmAw8OWPdhyJGhGSQGKRNJ45u9w==",
+            "version": "22.10.2",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
+            "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "undici-types": "~5.26.4"
+                "undici-types": "~6.20.0"
             }
         },
-        "node_modules/@types/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
-            "dev": true
-        },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-6.9.1.tgz",
-            "integrity": "sha512-w0tiiRc9I4S5XSXXrMHOWgHgxbrBn1Ro+PmiYhSg2ZVdxrAJtQgzU5o2m1BfP6UOn7Vxcc6152vFjQfmZR4xEg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.18.0.tgz",
+            "integrity": "sha512-NR2yS7qUqCL7AIxdJUQf2MKKNDVNaig/dEB0GBLU7D+ZdHgK1NoH/3wsgO3OnPVipn51tG3MAwaODEGil70WEw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@eslint-community/regexpp": "^4.5.1",
-                "@typescript-eslint/scope-manager": "6.9.1",
-                "@typescript-eslint/type-utils": "6.9.1",
-                "@typescript-eslint/utils": "6.9.1",
-                "@typescript-eslint/visitor-keys": "6.9.1",
-                "debug": "^4.3.4",
+                "@eslint-community/regexpp": "^4.10.0",
+                "@typescript-eslint/scope-manager": "8.18.0",
+                "@typescript-eslint/type-utils": "8.18.0",
+                "@typescript-eslint/utils": "8.18.0",
+                "@typescript-eslint/visitor-keys": "8.18.0",
                 "graphemer": "^1.4.0",
-                "ignore": "^5.2.4",
+                "ignore": "^5.3.1",
                 "natural-compare": "^1.4.0",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
+                "ts-api-utils": "^1.3.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^6.0.0 || ^6.0.0-alpha",
-                "eslint": "^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.8.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-6.9.1.tgz",
-            "integrity": "sha512-C7AK2wn43GSaCUZ9do6Ksgi2g3mwFkMO3Cis96kzmgudoVaKyt62yNzJOktP0HDLb/iO2O0n2lBOzJgr6Q/cyg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.18.0.tgz",
+            "integrity": "sha512-hgUZ3kTEpVzKaK3uNibExUYm6SKKOmTU2BOxBSvOYwtJEPdVQ70kZJpPjstlnhCHcuc2WGfSbpKlb/69ttyN5Q==",
             "dev": true,
+            "license": "MITClause",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "6.9.1",
-                "@typescript-eslint/types": "6.9.1",
-                "@typescript-eslint/typescript-estree": "6.9.1",
-                "@typescript-eslint/visitor-keys": "6.9.1",
+                "@typescript-eslint/scope-manager": "8.18.0",
+                "@typescript-eslint/types": "8.18.0",
+                "@typescript-eslint/typescript-estree": "8.18.0",
+                "@typescript-eslint/visitor-keys": "8.18.0",
                 "debug": "^4.3.4"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.8.0"
+            }
+        },
+        "node_modules/@typescript-eslint/rule-tester": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.18.0.tgz",
+            "integrity": "sha512-y3ZqVb6eMssPFJklplsQ+2MKcic7HqRgCkcu7MQryhRmqmhAgn+1hJnpqOipZIBTOWZeCiQ/X/XrbHdqjHFivQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/typescript-estree": "8.18.0",
+                "@typescript-eslint/utils": "8.18.0",
+                "ajv": "^6.12.6",
+                "json-stable-stringify-without-jsonify": "^1.0.1",
+                "lodash.merge": "4.6.2",
+                "semver": "^7.6.0"
             },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0"
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.9.1.tgz",
-            "integrity": "sha512-38IxvKB6NAne3g/+MyXMs2Cda/Sz+CEpmm+KLGEM8hx/CvnSRuw51i8ukfwB/B/sESdeTGet1NH1Wj7I0YXswg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.18.0.tgz",
+            "integrity": "sha512-PNGcHop0jkK2WVYGotk/hxj+UFLhXtGPiGtiaWgVBVP1jhMoMCHlTyJA+hEj4rszoSdLTK3fN4oOatrL0Cp+Xw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "6.9.1",
-                "@typescript-eslint/visitor-keys": "6.9.1"
+                "@typescript-eslint/types": "8.18.0",
+                "@typescript-eslint/visitor-keys": "8.18.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -341,39 +513,37 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.9.1.tgz",
-            "integrity": "sha512-eh2oHaUKCK58qIeYp19F5V5TbpM52680sB4zNSz29VBQPTWIlE/hCj5P5B1AChxECe/fmZlspAWFuRniep1Skg==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.18.0.tgz",
+            "integrity": "sha512-er224jRepVAVLnMF2Q7MZJCq5CsdH2oqjP4dT7K6ij09Kyd+R21r7UVJrF0buMVdZS5QRhDzpvzAxHxabQadow==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "6.9.1",
-                "@typescript-eslint/utils": "6.9.1",
+                "@typescript-eslint/typescript-estree": "8.18.0",
+                "@typescript-eslint/utils": "8.18.0",
                 "debug": "^4.3.4",
-                "ts-api-utils": "^1.0.1"
+                "ts-api-utils": "^1.3.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.8.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.9.1.tgz",
-            "integrity": "sha512-BUGslGOb14zUHOUmDB2FfT6SI1CcZEJYfF3qFwBeUrU6srJfzANonwRYHDpLBuzbq3HaoF2XL2hcr01c8f8OaQ==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.18.0.tgz",
+            "integrity": "sha512-FNYxgyTCAnFwTrzpBGq+zrnoTO4x0c1CKYY5MuUTzpScqmY5fmsh2o3+57lqdI3NZucBDCzDgdEbIaNfAjAHQA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
@@ -381,85 +551,93 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.9.1.tgz",
-            "integrity": "sha512-U+mUylTHfcqeO7mLWVQ5W/tMLXqVpRv61wm9ZtfE5egz7gtnmqVIw9ryh0mgIlkKk9rZLY3UHygsBSdB9/ftyw==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.18.0.tgz",
+            "integrity": "sha512-rqQgFRu6yPkauz+ms3nQpohwejS8bvgbPyIDq13cgEDbkXt4LH4OkDMT0/fN1RUtzG8e8AKJyDBoocuQh8qNeg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "6.9.1",
-                "@typescript-eslint/visitor-keys": "6.9.1",
+                "@typescript-eslint/types": "8.18.0",
+                "@typescript-eslint/visitor-keys": "8.18.0",
                 "debug": "^4.3.4",
-                "globby": "^11.1.0",
+                "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
-                "semver": "^7.5.4",
-                "ts-api-utils": "^1.0.1"
+                "minimatch": "^9.0.4",
+                "semver": "^7.6.0",
+                "ts-api-utils": "^1.3.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
-            },
-            "funding": {
-                "type": "opencollective",
-                "url": "https://opencollective.com/typescript-eslint"
-            },
-            "peerDependenciesMeta": {
-                "typescript": {
-                    "optional": true
-                }
-            }
-        },
-        "node_modules/@typescript-eslint/utils": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.9.1.tgz",
-            "integrity": "sha512-L1T0A5nFdQrMVunpZgzqPL6y2wVreSyHhKGZryS6jrEN7bD9NplVAyMryUhXsQ4TWLnZmxc2ekar/lSGIlprCA==",
-            "dev": true,
-            "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@types/json-schema": "^7.0.12",
-                "@types/semver": "^7.5.0",
-                "@typescript-eslint/scope-manager": "6.9.1",
-                "@typescript-eslint/types": "6.9.1",
-                "@typescript-eslint/typescript-estree": "6.9.1",
-                "semver": "^7.5.4"
-            },
-            "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "eslint": "^7.0.0 || ^8.0.0"
+                "typescript": ">=4.8.4 <5.8.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.18.0.tgz",
+            "integrity": "sha512-p6GLdY383i7h5b0Qrfbix3Vc3+J2k6QWw6UMUeY5JGfm3C5LbZ4QIZzJNoNOfgyRe0uuYKjvVOsO/jD4SJO+xg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.4.0",
+                "@typescript-eslint/scope-manager": "8.18.0",
+                "@typescript-eslint/types": "8.18.0",
+                "@typescript-eslint/typescript-estree": "8.18.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.8.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "6.9.1",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.9.1.tgz",
-            "integrity": "sha512-MUaPUe/QRLEffARsmNfmpghuQkW436DvESW+h+M52w0coICHRfD6Np9/K6PdACwnrq1HmuLl+cSPZaJmeVPkSw==",
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.18.0.tgz",
+            "integrity": "sha512-pCh/qEA8Lb1wVIqNvBke8UaRjJ6wrAWkJO5yyIbs8Yx6TNGYyfNjOo61tLv+WwLvoLPp4BQ8B7AHKijl8NGUfw==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "6.9.1",
-                "eslint-visitor-keys": "^3.4.1"
+                "@typescript-eslint/types": "8.18.0",
+                "eslint-visitor-keys": "^4.2.0"
             },
             "engines": {
-                "node": "^16.0.0 || >=18.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
-        "node_modules/@ungap/structured-clone": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
-            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
-            "dev": true
+        "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
         },
         "node_modules/acorn": {
-            "version": "8.11.2",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
-            "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
+            "version": "8.14.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
             "dev": true,
+            "license": "MIT",
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -472,15 +650,21 @@
             "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
             "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.3.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
-            "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
+            "version": "8.3.4",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.4.tgz",
+            "integrity": "sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==",
             "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "acorn": "^8.11.0"
+            },
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -490,6 +674,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
             "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -501,20 +686,13 @@
                 "url": "https://github.com/sponsors/epoberezkin"
             }
         },
-        "node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
         "node_modules/ansi-styles": {
             "version": "4.3.0",
             "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
             "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "color-convert": "^2.0.1"
             },
@@ -529,46 +707,42 @@
             "version": "4.1.3",
             "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
             "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
             "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-            "dev": true
-        },
-        "node_modules/array-union": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
             "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
+            "license": "Python-2.0",
+            "peer": true
         },
         "node_modules/balanced-match": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
             "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "balanced-match": "^1.0.0",
-                "concat-map": "0.0.1"
+                "balanced-match": "^1.0.0"
             }
         },
         "node_modules/braces": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-            "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+            "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "fill-range": "^7.0.1"
+                "fill-range": "^7.1.1"
             },
             "engines": {
                 "node": ">=8"
@@ -579,6 +753,8 @@
             "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
             "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=6"
             }
@@ -588,6 +764,8 @@
             "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
             "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "ansi-styles": "^4.1.0",
                 "supports-color": "^7.1.0"
@@ -604,6 +782,8 @@
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
             "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "color-name": "~1.1.4"
             },
@@ -615,25 +795,32 @@
             "version": "1.1.4",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
             "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-            "dev": true
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/concat-map": {
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/create-require": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
             "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/cross-spawn": {
-            "version": "7.0.3",
-            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-            "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+            "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "path-key": "^3.1.0",
                 "shebang-command": "^2.0.0",
@@ -644,12 +831,13 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.3.4",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.4.tgz",
-            "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "ms": "2.1.2"
+                "ms": "^2.1.3"
             },
             "engines": {
                 "node": ">=6.0"
@@ -664,39 +852,18 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
             "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/diff": {
             "version": "4.0.2",
             "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
             "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
             "dev": true,
+            "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
-            }
-        },
-        "node_modules/dir-glob": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-            "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-            "dev": true,
-            "dependencies": {
-                "path-type": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/doctrine": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
-            "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
-            "dev": true,
-            "dependencies": {
-                "esutils": "^2.0.2"
-            },
-            "engines": {
-                "node": ">=6.0.0"
             }
         },
         "node_modules/escape-string-regexp": {
@@ -704,6 +871,8 @@
             "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
             "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },
@@ -712,71 +881,79 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.53.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.53.0.tgz",
-            "integrity": "sha512-N4VuiPjXDUa4xVeV/GC/RV3hQW9Nw+Y463lkWaKKXKYMvmRiRDAtfpuPFLN+E1/6ZhyR8J2ig+eVREnYgUsiag==",
+            "version": "9.16.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.16.0.tgz",
+            "integrity": "sha512-whp8mSQI4C8VXd+fLgSM0lh3UlmcFtVwUQjyKCFfsp+2ItAIYhlq/hqGahGqHE6cv9unM41VlqKk2VtKYR2TaA==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
-                "@eslint-community/regexpp": "^4.6.1",
-                "@eslint/eslintrc": "^2.1.3",
-                "@eslint/js": "8.53.0",
-                "@humanwhocodes/config-array": "^0.11.13",
+                "@eslint-community/regexpp": "^4.12.1",
+                "@eslint/config-array": "^0.19.0",
+                "@eslint/core": "^0.9.0",
+                "@eslint/eslintrc": "^3.2.0",
+                "@eslint/js": "9.16.0",
+                "@eslint/plugin-kit": "^0.2.3",
+                "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@nodelib/fs.walk": "^1.2.8",
-                "@ungap/structured-clone": "^1.2.0",
+                "@humanwhocodes/retry": "^0.4.1",
+                "@types/estree": "^1.0.6",
+                "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
-                "cross-spawn": "^7.0.2",
+                "cross-spawn": "^7.0.5",
                 "debug": "^4.3.2",
-                "doctrine": "^3.0.0",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^7.2.2",
-                "eslint-visitor-keys": "^3.4.3",
-                "espree": "^9.6.1",
-                "esquery": "^1.4.2",
+                "eslint-scope": "^8.2.0",
+                "eslint-visitor-keys": "^4.2.0",
+                "espree": "^10.3.0",
+                "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
-                "file-entry-cache": "^6.0.1",
+                "file-entry-cache": "^8.0.0",
                 "find-up": "^5.0.0",
                 "glob-parent": "^6.0.2",
-                "globals": "^13.19.0",
-                "graphemer": "^1.4.0",
                 "ignore": "^5.2.0",
                 "imurmurhash": "^0.1.4",
                 "is-glob": "^4.0.0",
-                "is-path-inside": "^3.0.3",
-                "js-yaml": "^4.1.0",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
-                "levn": "^0.4.1",
                 "lodash.merge": "^4.6.2",
                 "minimatch": "^3.1.2",
                 "natural-compare": "^1.4.0",
-                "optionator": "^0.9.3",
-                "strip-ansi": "^6.0.1",
-                "text-table": "^0.2.0"
+                "optionator": "^0.9.3"
             },
             "bin": {
                 "eslint": "bin/eslint.js"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
-                "url": "https://opencollective.com/eslint"
+                "url": "https://eslint.org/donate"
+            },
+            "peerDependencies": {
+                "jiti": "*"
+            },
+            "peerDependenciesMeta": {
+                "jiti": {
+                    "optional": true
+                }
             }
         },
         "node_modules/eslint-scope": {
-            "version": "7.2.2",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-7.2.2.tgz",
-            "integrity": "sha512-dOt21O7lTMhDM+X9mB4GX+DZrZtCUJPL/wlcTqxyrx5IvO0IYtILdtrQGQp+8n5S0gwSVmOf9NQrjMOgfQZlIg==",
+            "version": "8.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
+            "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
             "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "esrecurse": "^4.3.0",
                 "estraverse": "^5.2.0"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
@@ -787,6 +964,7 @@
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-3.4.3.tgz",
             "integrity": "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag==",
             "dev": true,
+            "license": "Apache-2.0",
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             },
@@ -794,28 +972,86 @@
                 "url": "https://opencollective.com/eslint"
             }
         },
-        "node_modules/espree": {
-            "version": "9.6.1",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
-            "integrity": "sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==",
+        "node_modules/eslint/node_modules/brace-expansion": {
+            "version": "1.1.11",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "acorn": "^8.9.0",
-                "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^3.4.1"
+                "balanced-match": "^1.0.0",
+                "concat-map": "0.0.1"
+            }
+        },
+        "node_modules/eslint/node_modules/eslint-visitor-keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/eslint/node_modules/minimatch": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "dev": true,
+            "license": "ISC",
+            "peer": true,
+            "dependencies": {
+                "brace-expansion": "^1.1.7"
             },
             "engines": {
-                "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+                "node": "*"
+            }
+        },
+        "node_modules/espree": {
+            "version": "10.3.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
+            "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
+            "dependencies": {
+                "acorn": "^8.14.0",
+                "acorn-jsx": "^5.3.2",
+                "eslint-visitor-keys": "^4.2.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
+        "node_modules/espree/node_modules/eslint-visitor-keys": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
+            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "peer": true,
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
         },
         "node_modules/esquery": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.5.0.tgz",
-            "integrity": "sha512-YQLXUplAwJgCydQ78IMJywZCceoqk1oH01OERdSAJc/7U2AylwjhSCLDEtqwg811idIS/9fIU5GjG73IgjKMVg==",
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.6.0.tgz",
+            "integrity": "sha512-ca9pw9fomFcKPvFLXhBKUK90ZvGibiGOvRJNbjljY7s7uq/5YO4BOzcYtJqExdx99rF6aAcnRxHmcUHcz6sQsg==",
             "dev": true,
+            "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "estraverse": "^5.1.0"
             },
@@ -828,6 +1064,8 @@
             "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
             "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
             "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "estraverse": "^5.2.0"
             },
@@ -840,6 +1078,8 @@
             "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
             "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
             "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=4.0"
             }
@@ -849,6 +1089,8 @@
             "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true,
+            "license": "BSD-2-Clause",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -857,13 +1099,15 @@
             "version": "3.1.3",
             "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
             "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fast-glob": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.1.tgz",
-            "integrity": "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.2.tgz",
+            "integrity": "sha512-oX2ruAFQwf/Orj8m737Y5adxDQO0LAB7/S5MnxCdTNDd4p6BsyIVsv9JQsATbTSq8KHRpLwIHbVlUNatxd+1Ow==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -880,6 +1124,7 @@
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
             "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "is-glob": "^4.0.1"
             },
@@ -891,40 +1136,47 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
             "integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/fast-levenshtein": {
             "version": "2.0.6",
             "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
             "integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/fastq": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
-            "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
+            "version": "1.17.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.17.1.tgz",
+            "integrity": "sha512-sRVD3lWVIXWg6By68ZN7vho9a1pQcN/WBFaAAsDDFzlJjvoGx0P8z7V1t72grFJfJhu3YPZBuu25f7Kaw2jN1w==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
                 "reusify": "^1.0.4"
             }
         },
         "node_modules/file-entry-cache": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
-            "integrity": "sha512-7Gps/XWymbLk2QLYK4NzpMOrYjMhdIxXuIvy2QBsLE6ljuodKvdkWs/cpyJJ3CVIVpH0Oi1Hvg1ovbMzLdFBBg==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
+            "integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "flat-cache": "^3.0.4"
+                "flat-cache": "^4.0.0"
             },
             "engines": {
-                "node": "^10.12.0 || >=12.0.0"
+                "node": ">=16.0.0"
             }
         },
         "node_modules/fill-range": {
-            "version": "7.0.1",
-            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-            "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+            "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "to-regex-range": "^5.0.1"
             },
@@ -937,6 +1189,8 @@
             "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
             "integrity": "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "locate-path": "^6.0.0",
                 "path-exists": "^4.0.0"
@@ -949,56 +1203,35 @@
             }
         },
         "node_modules/flat-cache": {
-            "version": "3.1.1",
-            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-3.1.1.tgz",
-            "integrity": "sha512-/qM2b3LUIaIgviBQovTLvijfyOQXPtSRnRK26ksj2J7rzPIecePUIpJsZ4T02Qg+xiAEKIs5K8dsHEd+VaKa/Q==",
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
+            "integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "flatted": "^3.2.9",
-                "keyv": "^4.5.3",
-                "rimraf": "^3.0.2"
+                "keyv": "^4.5.4"
             },
             "engines": {
-                "node": ">=12.0.0"
+                "node": ">=16"
             }
         },
         "node_modules/flatted": {
-            "version": "3.2.9",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.2.9.tgz",
-            "integrity": "sha512-36yxDn5H7OFZQla0/jFJmbIKTdZAQHngCedGxiMmpNfEZM0sdEeT+WczLQrjK6D7o2aiyLYDnkw0R3JK0Qv1RQ==",
-            "dev": true
-        },
-        "node_modules/fs.realpath": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-            "integrity": "sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==",
-            "dev": true
-        },
-        "node_modules/glob": {
-            "version": "7.2.3",
-            "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
-            "integrity": "sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
+            "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
             "dev": true,
-            "dependencies": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.1.1",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-            },
-            "engines": {
-                "node": "*"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
-            }
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/glob-parent": {
             "version": "6.0.2",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
             "integrity": "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==",
             "dev": true,
+            "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "is-glob": "^4.0.3"
             },
@@ -1007,35 +1240,14 @@
             }
         },
         "node_modules/globals": {
-            "version": "13.23.0",
-            "resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-            "integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+            "version": "14.0.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
+            "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
             "dev": true,
-            "dependencies": {
-                "type-fest": "^0.20.2"
-            },
+            "license": "MIT",
+            "peer": true,
             "engines": {
-                "node": ">=8"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
-        "node_modules/globby": {
-            "version": "11.1.0",
-            "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
-            "integrity": "sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==",
-            "dev": true,
-            "dependencies": {
-                "array-union": "^2.1.0",
-                "dir-glob": "^3.0.1",
-                "fast-glob": "^3.2.9",
-                "ignore": "^5.2.0",
-                "merge2": "^1.4.1",
-                "slash": "^3.0.0"
-            },
-            "engines": {
-                "node": ">=10"
+                "node": ">=18"
             },
             "funding": {
                 "url": "https://github.com/sponsors/sindresorhus"
@@ -1045,22 +1257,26 @@
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/graphemer/-/graphemer-1.4.0.tgz",
             "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/has-flag": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
             "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
         },
         "node_modules/ignore": {
-            "version": "5.2.4",
-            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
-            "integrity": "sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==",
+            "version": "5.3.2",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+            "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 4"
             }
@@ -1070,6 +1286,8 @@
             "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
             "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "parent-module": "^1.0.0",
                 "resolve-from": "^4.0.0"
@@ -1086,31 +1304,18 @@
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
             "integrity": "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.8.19"
             }
-        },
-        "node_modules/inflight": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
-            "integrity": "sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==",
-            "dev": true,
-            "dependencies": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-            }
-        },
-        "node_modules/inherits": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-            "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-            "dev": true
         },
         "node_modules/is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
             "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -1120,6 +1325,7 @@
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
             "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-extglob": "^2.1.1"
             },
@@ -1132,30 +1338,26 @@
             "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
             "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=0.12.0"
-            }
-        },
-        "node_modules/is-path-inside": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-3.0.3.tgz",
-            "integrity": "sha512-Fd4gABb+ycGAmKou8eMftCupSir5lRxqf4aD/vd0cD2qc4HL07OjCeuHMr8Ro4CoMaeCKDB0/ECBOVWjTwUvPQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
             }
         },
         "node_modules/isexe": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
             "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
-            "dev": true
+            "dev": true,
+            "license": "ISC",
+            "peer": true
         },
         "node_modules/js-yaml": {
             "version": "4.1.0",
             "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
             "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "argparse": "^2.0.1"
             },
@@ -1167,25 +1369,31 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
             "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
-            "dev": true
+            "dev": true,
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/keyv": {
             "version": "4.5.4",
             "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
             "integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "json-buffer": "3.0.1"
             }
@@ -1195,6 +1403,8 @@
             "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
             "integrity": "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1",
                 "type-check": "~0.4.0"
@@ -1208,6 +1418,8 @@
             "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
             "integrity": "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-locate": "^5.0.0"
             },
@@ -1222,42 +1434,34 @@
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-            "dev": true
-        },
-        "node_modules/lru-cache": {
-            "version": "6.0.0",
-            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-            "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
             "dev": true,
-            "dependencies": {
-                "yallist": "^4.0.0"
-            },
-            "engines": {
-                "node": ">=10"
-            }
+            "license": "MIT"
         },
         "node_modules/make-error": {
             "version": "1.3.6",
             "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
             "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-            "dev": true
+            "dev": true,
+            "license": "ISC"
         },
         "node_modules/merge2": {
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
             "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">= 8"
             }
         },
         "node_modules/micromatch": {
-            "version": "4.0.5",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
-            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
+            "version": "4.0.8",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+            "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
-                "braces": "^3.0.2",
+                "braces": "^3.0.3",
                 "picomatch": "^2.3.1"
             },
             "engines": {
@@ -1265,55 +1469,55 @@
             }
         },
         "node_modules/minimatch": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-            "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+            "version": "9.0.5",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
+            "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
+            "license": "ISC",
             "dependencies": {
-                "brace-expansion": "^1.1.7"
+                "brace-expansion": "^2.0.1"
             },
             "engines": {
-                "node": "*"
+                "node": ">=16 || 14 >=14.17"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/module-alias": {
             "version": "2.2.3",
             "resolved": "https://registry.npmjs.org/module-alias/-/module-alias-2.2.3.tgz",
-            "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q=="
+            "integrity": "sha512-23g5BFj4zdQL/b6tor7Ji+QY4pEfNH784BMslY9Qb0UnJWRAt+lQGLYmRaM0KDBwIG23ffEBELhZDP2rhi9f/Q==",
+            "license": "MIT"
         },
         "node_modules/ms": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-            "dev": true
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/natural-compare": {
             "version": "1.4.0",
             "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
             "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
-            "dev": true
-        },
-        "node_modules/once": {
-            "version": "1.4.0",
-            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
-            "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
             "dev": true,
-            "dependencies": {
-                "wrappy": "1"
-            }
+            "license": "MIT"
         },
         "node_modules/optionator": {
-            "version": "0.9.3",
-            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.3.tgz",
-            "integrity": "sha512-JjCoypp+jKn1ttEFExxhetCKeJt9zhAgAve5FXHixTvFDW/5aEktX9bufBKLRRMdU7bNtpLfcGu94B3cdEJgjg==",
+            "version": "0.9.4",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
+            "integrity": "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@aashutoshrathi/word-wrap": "^1.2.3",
                 "deep-is": "^0.1.3",
                 "fast-levenshtein": "^2.0.6",
                 "levn": "^0.4.1",
                 "prelude-ls": "^1.2.1",
-                "type-check": "^0.4.0"
+                "type-check": "^0.4.0",
+                "word-wrap": "^1.2.5"
             },
             "engines": {
                 "node": ">= 0.8.0"
@@ -1324,6 +1528,8 @@
             "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
             "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "yocto-queue": "^0.1.0"
             },
@@ -1339,6 +1545,8 @@
             "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
             "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "p-limit": "^3.0.2"
             },
@@ -1354,6 +1562,8 @@
             "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
             "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "callsites": "^3.0.0"
             },
@@ -1366,17 +1576,10 @@
             "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
             "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
-            }
-        },
-        "node_modules/path-is-absolute": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-            "integrity": "sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==",
-            "dev": true,
-            "engines": {
-                "node": ">=0.10.0"
             }
         },
         "node_modules/path-key": {
@@ -1384,15 +1587,8 @@
             "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
             "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
             "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/path-type": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-            "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-            "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -1402,6 +1598,7 @@
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
             "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=8.6"
             },
@@ -1414,6 +1611,8 @@
             "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
             "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">= 0.8.0"
             }
@@ -1423,6 +1622,7 @@
             "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
             "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -1445,13 +1645,16 @@
                     "type": "consulting",
                     "url": "https://feross.org/support"
                 }
-            ]
+            ],
+            "license": "MIT"
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
             "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=4"
             }
@@ -1461,24 +1664,10 @@
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
             "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "iojs": ">=1.0.0",
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/rimraf": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
-            "integrity": "sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==",
-            "dev": true,
-            "dependencies": {
-                "glob": "^7.1.3"
-            },
-            "bin": {
-                "rimraf": "bin.js"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/isaacs"
             }
         },
         "node_modules/run-parallel": {
@@ -1500,18 +1689,17 @@
                     "url": "https://feross.org/support"
                 }
             ],
+            "license": "MIT",
             "dependencies": {
                 "queue-microtask": "^1.2.2"
             }
         },
         "node_modules/semver": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
-            "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+            "version": "7.6.3",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
+            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
             "dev": true,
-            "dependencies": {
-                "lru-cache": "^6.0.0"
-            },
+            "license": "ISC",
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -1524,6 +1712,8 @@
             "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
             "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "shebang-regex": "^3.0.0"
             },
@@ -1536,27 +1726,8 @@
             "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
             "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
             "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/slash": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
-            "dev": true,
-            "engines": {
-                "node": ">=8"
-            }
-        },
-        "node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-            "dev": true,
-            "dependencies": {
-                "ansi-regex": "^5.0.1"
-            },
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             }
@@ -1566,6 +1737,8 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
             "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=8"
             },
@@ -1578,6 +1751,8 @@
             "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
             "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "has-flag": "^4.0.0"
             },
@@ -1585,17 +1760,12 @@
                 "node": ">=8"
             }
         },
-        "node_modules/text-table": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-            "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
-            "dev": true
-        },
         "node_modules/to-regex-range": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
             "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "is-number": "^7.0.0"
             },
@@ -1604,22 +1774,24 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.0.3.tgz",
-            "integrity": "sha512-wNMeqtMz5NtwpT/UZGY5alT+VoKdSsOOP/kqHFcUW1P/VRhH2wJ48+DN2WwUliNbQ976ETwDL0Ifd2VVvgonvg==",
+            "version": "1.4.3",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
+            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
             "dev": true,
+            "license": "MIT",
             "engines": {
-                "node": ">=16.13.0"
+                "node": ">=16"
             },
             "peerDependencies": {
                 "typescript": ">=4.2.0"
             }
         },
         "node_modules/ts-node": {
-            "version": "10.9.1",
-            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
-            "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
+            "version": "10.9.2",
+            "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.2.tgz",
+            "integrity": "sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==",
             "dev": true,
+            "license": "MIT",
             "dependencies": {
                 "@cspotcode/source-map-support": "^0.8.0",
                 "@tsconfig/node10": "^1.0.7",
@@ -1663,6 +1835,8 @@
             "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
             "integrity": "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prelude-ls": "^1.2.1"
             },
@@ -1670,42 +1844,56 @@
                 "node": ">= 0.8.0"
             }
         },
-        "node_modules/type-fest": {
-            "version": "0.20.2",
-            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.20.2.tgz",
-            "integrity": "sha512-Ne+eE4r0/iWnpAxD852z3A+N0Bt5RN//NjJwRd2VFHEmrywxf5vsZlh4R6lixl6B+wz/8d+maTSAkN1FIkI3LQ==",
-            "dev": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/sindresorhus"
-            }
-        },
         "node_modules/typescript": {
-            "version": "4.9.5",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-            "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
             "dev": true,
+            "license": "Apache-2.0",
             "bin": {
                 "tsc": "bin/tsc",
                 "tsserver": "bin/tsserver"
             },
             "engines": {
-                "node": ">=4.2.0"
+                "node": ">=14.17"
+            }
+        },
+        "node_modules/typescript-eslint": {
+            "version": "8.18.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.18.0.tgz",
+            "integrity": "sha512-Xq2rRjn6tzVpAyHr3+nmSg1/9k9aIHnJ2iZeOH7cfGOWqTkXTm3kwpQglEuLGdNrYvPF+2gtAs+/KF5rjVo+WQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/eslint-plugin": "8.18.0",
+                "@typescript-eslint/parser": "8.18.0",
+                "@typescript-eslint/utils": "8.18.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0",
+                "typescript": ">=4.8.4 <5.8.0"
             }
         },
         "node_modules/undici-types": {
-            "version": "5.26.5",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-            "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-            "dev": true
+            "version": "6.20.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/uri-js": {
             "version": "4.4.1",
             "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
             "integrity": "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==",
             "dev": true,
+            "license": "BSD-2-Clause",
             "dependencies": {
                 "punycode": "^2.1.0"
             }
@@ -1714,13 +1902,16 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
             "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-            "dev": true
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/which": {
             "version": "2.0.2",
             "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
             "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
             "dev": true,
+            "license": "ISC",
+            "peer": true,
             "dependencies": {
                 "isexe": "^2.0.0"
             },
@@ -1731,23 +1922,23 @@
                 "node": ">= 8"
             }
         },
-        "node_modules/wrappy": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-            "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-            "dev": true
-        },
-        "node_modules/yallist": {
-            "version": "4.0.0",
-            "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+        "node_modules/word-wrap": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
+            "integrity": "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==",
+            "dev": true,
+            "license": "MIT",
+            "peer": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
         },
         "node_modules/yn": {
             "version": "3.1.1",
             "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
             "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=6"
             }
@@ -1757,6 +1948,8 @@
             "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
             "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
             "dev": true,
+            "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             },

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "type": "commonjs",
     "repository": {
         "type": "git",
-        "url": "https://github.com/adashrod/eslint-plugin-sequence"
+        "url": "git+https://github.com/adashrod/eslint-plugin-sequence.git"
     },
     "bugs": {
         "url": "https://github.com/adashrod/eslint-plugin-sequence/issues"

--- a/package.json
+++ b/package.json
@@ -1,20 +1,21 @@
 {
     "name": "eslint-plugin-sequence",
-    "version": "0.6.1",
+    "version": "0.7.0",
     "description": "A collection of EsLint rules variously related to sequences: import sorting, ordering, etc",
     "main": "index.js",
     "dependencies": {
         "module-alias": "^2.2.3"
     },
     "devDependencies": {
-        "@types/eslint": "^8.44.6",
-        "@types/module-alias": "^2.0.3",
-        "@types/node": "^20.8.10",
-        "@typescript-eslint/eslint-plugin": "^6.9.1",
-        "@typescript-eslint/parser": "^6.9.1",
-        "eslint": "^8.53.0",
-        "ts-node": "^10.9.1",
-        "typescript": "^4.5.4"
+        "@eslint/js": "^9.16.0",
+        "@types/eslint": "^9.6.1",
+        "@types/module-alias": "^2.0.4",
+        "@types/node": "^22.10.2",
+        "@typescript-eslint/parser": "^8.18.0",
+        "@typescript-eslint/rule-tester": "^8.18.0",
+        "ts-node": "^10.9.2",
+        "typescript": "^5.7.2",
+        "typescript-eslint": "^8.18.0"
     },
     "scripts": {
         "test": "ts-node src/tests/test-all.ts",

--- a/src/tests/rules/logical-expression-complexity.ts
+++ b/src/tests/rules/logical-expression-complexity.ts
@@ -2,12 +2,14 @@ import { RuleTester } from "eslint";
 
 import logicalExpressionComplexityRule from "@adashrodEps/lib/rules/logical-expression-complexity";
 
-const es5RuleTester = new RuleTester({
-    parserOptions: {
-        ecmaVersion: 13,
+const esRuleTester = new RuleTester({
+    languageOptions: {
+        parserOptions: {
+            ecmaVersion: 13,
+        }
     }
 });
-es5RuleTester.run("logical-expression-complexity", logicalExpressionComplexityRule, {
+esRuleTester.run("logical-expression-complexity", logicalExpressionComplexityRule, {
     valid: [
         `let a, b, c; let res = a && b && c;`,
         `let a, b; let res = a ?? b;`,
@@ -30,6 +32,9 @@ es5RuleTester.run("logical-expression-complexity", logicalExpressionComplexityRu
         }, {
             code: `let a, b, c, d, e, f; let res = (a && b && c) ? (d || e || f) : (g && h || i);`,
             options: [{ includeTernary: false }]
+        }, {
+            code: `let a, b, c, d, e, f, g, h; let res = (a && b || c && d) || e && f && g && h`,
+            options: [{ maxHeight: 0, maxTerms: 0 }]
         }
     ],
     invalid: [{

--- a/src/tests/rules/ordered-import-members.ts
+++ b/src/tests/rules/ordered-import-members.ts
@@ -1,11 +1,13 @@
+import { parse } from "@typescript-eslint/parser";
 import { RuleTester } from "eslint";
 
 import orderedImportMembersRule from "@adashrodEps/lib/rules/ordered-import-members";
 
 const esRuleTester = new RuleTester({
-    parserOptions: {
-        ecmaVersion: 6,
-        sourceType: "module",
+    languageOptions: {
+        parserOptions: {
+            ecmaVersion: 6
+        }
     }
 });
 
@@ -116,7 +118,9 @@ esRuleTester.run("ordered-import-members", orderedImportMembersRule, {
 });
 
 const tsRuleTester = new RuleTester({
-    parser: require.resolve('@typescript-eslint/parser')
+    languageOptions: {
+        parser: { parse }
+    }
 });
 
 tsRuleTester.run("ordered-import-members", orderedImportMembersRule, {

--- a/src/tests/rules/ordered-imports-by-path.ts
+++ b/src/tests/rules/ordered-imports-by-path.ts
@@ -1,11 +1,13 @@
+import { parse } from "@typescript-eslint/parser";
 import { RuleTester } from "eslint";
 
 import orderedImportsByPathRule from "@adashrodEps/lib/rules/ordered-imports-by-path";
 
 const esRuleTester = new RuleTester({
-    parserOptions: {
-        ecmaVersion: 6,
-        sourceType: "module",
+    languageOptions:{
+        parserOptions: {
+            ecmaVersion: 6
+        }
     }
 });
 
@@ -165,7 +167,9 @@ esRuleTester.run("ordered-imports-by-path", orderedImportsByPathRule, {
 });
 
 const tsRuleTester = new RuleTester({
-    parser: require.resolve('@typescript-eslint/parser')
+    languageOptions: {   
+        parser: { parse }
+    }
 });
 tsRuleTester.run("ordered-imports-by-path", orderedImportsByPathRule, {
     valid: [{

--- a/src/tests/rules/strict-camel-case.ts
+++ b/src/tests/rules/strict-camel-case.ts
@@ -1,63 +1,17 @@
-import { RuleTester } from "eslint";
+import { parse } from "@typescript-eslint/parser";
+import { RuleTester as TsEsLintRuleTester } from "@typescript-eslint/rule-tester";
+import { ESLintUtils as EsLintUtils } from '@typescript-eslint/utils';
+import { RuleTester as EsLintRuleTester } from "eslint";
 
 import strictCamelCaseRule from "@adashrodEps/lib/rules/strict-camel-case";
+import EventEmitter from "events";
 
-const es5RuleTester = new RuleTester({
-    parserOptions: {
-        ecmaVersion: 5,
-    }
-});
-es5RuleTester.run("strict-camel-case", strictCamelCaseRule, {
-    valid: [
-        `var anXmlString = "";`,
-        `var xmlToHtml = function() {};`,
-        `function xmlToHtml() {}`,
-        `this.aGlobalVar = true;`,
-        `anotherGlobalVar = true;`
-    ],
-    invalid: [{
-        code: `var aVAR = 5, aVar2 = 1;`,
-        errors: [{
-            suggestions: [{
-                output: `var aVar = 5, aVar2 = 1;`
-            }]
-        }]
-    }, {
-        code: `var xmlToHTML = function() {};`,
-        errors: [{
-            suggestions: [{
-                output: `var xmlToHtml = function() {};`
-            }]
-        }]
-    }, {
-        code: `function xmlToHTML() {};`,
-        errors: [{
-            suggestions: [{
-                output: `function xmlToHtml() {};`
-            }]
-        }]
-    }, {
-        code: `this.aGLOBALVar = 5;`,
-        errors: [{
-            suggestions: [{
-                output: `this.aGlobalVar = 5;`
-            }]
-        }]
-    }, {
-        code: `aGLOBALVar = 5;`,
-        errors: [{
-            suggestions: [{
-                output: `aGlobalVar = 5;`
-            }]
-        }]
-    }]
-});
-
-const es13RuleTester = new RuleTester({
-    parserOptions: {
-        // 13 has support for # private field/function syntax
-        ecmaVersion: 13,
-        sourceType: "module"
+const es13RuleTester = new EsLintRuleTester({
+    languageOptions: {
+        parserOptions: {
+            // 13 has support for # private field/function syntax
+            ecmaVersion: 13
+        }
     }
 });
 es13RuleTester.run("strict-camel-case", strictCamelCaseRule, {
@@ -140,263 +94,252 @@ es13RuleTester.run("strict-camel-case", strictCamelCaseRule, {
     invalid: [{
         code:  `const obj = {}; obj.VERSION = "1.0";`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `const obj = {}; obj.Version = "1.0";`
             }]
         }]
     }, {
         code: `let xmlToHTML = () => {};`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `let xmlToHtml = () => {};`,
             }]
         }]
     }, {
         code: `const AFunction = () => {};`,
         errors: [{
-            message: `Identifier "AFunction" is not in strict camel case, no suggestion possible for 1-char words.`
+            messageId: "notCamelCaseNoSuggestion"
         }]
     }, {
         code: `const AFunction = () => {};`,
         options: [{ allowOneCharWords: "last" }],
         errors: [{
-            message: `Identifier "AFunction" is not in strict camel case, no suggestion possible for 1-char words.`
+            messageId: "notCamelCaseNoSuggestion"
         }]
     }, {
         code: `class API {}`,
         options: [{ ignoreSingleWords: false }],
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class Api {}`
             }]
         }]
     }, {
         code: `const apiApiAPI = () => {};`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `const apiApiApi = () => {};`
             }]
         }]
     }, {
         code: `const someFunc = (firstParam, secondPARAM) => {};`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `const someFunc = (firstParam, secondParam) => {};`
             }]
         }]
     }, {
         code: `const func = function(firstPARAM, secondParam) {};`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `const func = function(firstParam, secondParam) {};`
             }]
         }]
     }, {
         code: `const func = function myFUNC(firstParam, secondParam) {};`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `const func = function myFunc(firstParam, secondParam) {};`
             }]
         }]
     }, {
         code: `class MyAPIClass {}`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class MyApiClass {}`
             }]
         }]
     }, {
         code: `const MyAPIClass = class {}`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `const MyApiClass = class {}`
             }]
         }]
     }, {
         code: `try { throw new Error(); } catch (anIOException) {}`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `try { throw new Error(); } catch (anIoException) {}`
             }]
         }]
     }, {
         code: `let obj = { htmlAPI: "..." };`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `let obj = { htmlApi: "..." };`
             }]
         }]
     }, {
         code: `class MyClass { convertToXML(html) {} }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class MyClass { convertToXml(html) {} }`
             }]
         }]
     }, {
         code: `class MyClass { convertToXml(theHTML) {} }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class MyClass { convertToXml(theHtml) {} }`
             }]
         }]
     }, {
         code: `class MyClass { convertToXML(theHTML) {} }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class MyClass { convertToXml(theHTML) {} }`
             }]
         }, {
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class MyClass { convertToXML(theHtml) {} }`
             }]
         }]
     }, {
         code: `class MyClass { constructor() { this.myAPI = null; } }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class MyClass { constructor() { this.myApi = null; } }`
             }]
         }]
     }, {
         code: `class TheClass { #somePrivateTXT = 5; }`,
         errors: [{
+            messageId: "notCamelCasePrivateWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class TheClass { #somePrivateTxt = 5; }`
             }]
         }]
     }, {
         code: `class SomeClass { #privateAPICall() {} }`,
         errors: [{
+            messageId: "notCamelCasePrivateWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class SomeClass { #privateApiCall() {} }`
             }]
         }]
     }, {
         code: `class TheClass { constructor() { this.myAPI = {}; } }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class TheClass { constructor() { this.myApi = {}; } }`
-            }]
-        }]
-    }, {
-        code: `myXYZLabel1:
-        my_label_2:
-        for (let i = 0; i < 5; i++) {
-            if (i == 3) {
-                break my_label_2;
-            }
-        }`,
-        errors: [{
-            suggestions: [{
-                output: `myXyzLabel1:
-        my_label_2:
-        for (let i = 0; i < 5; i++) {
-            if (i == 3) {
-                break my_label_2;
-            }
-        }`
-            }]
-        }, {
-            suggestions: [{
-                output: `myXYZLabel1:
-        myLabel2:
-        for (let i = 0; i < 5; i++) {
-            if (i == 3) {
-                break my_label_2;
-            }
-        }`
-            }]
-        }, {
-            suggestions: [{
-                output: `myXYZLabel1:
-        my_label_2:
-        for (let i = 0; i < 5; i++) {
-            if (i == 3) {
-                break myLabel2;
-            }
-        }`
-            }]
-        }]
-    }, {
-        code: `label_2:
-        for (let i = 0; i < 5; i++) {
-            if (i == 3) {
-                continue label_2;
-            }
-        }`,
-        errors: [{
-            suggestions:[{
-                output: `label2:
-        for (let i = 0; i < 5; i++) {
-            if (i == 3) {
-                continue label_2;
-            }
-        }`
-            }]
-        }, {
-            suggestions: [{
-                output: `label_2:
-        for (let i = 0; i < 5; i++) {
-            if (i == 3) {
-                continue label2;
-            }
-        }`
             }]
         }]
     }, {
         code: `export function toXML() {}`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `export function toXml() {}`
             }]
         }]
     }, {
         code: `export { default as some_stuff } from "/utils"`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `export { default as someStuff } from "/utils"`
             }]
         }]
     }, {
         code: `import * as FS from "fs"`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `import * as Fs from "fs"`
             }]
         }]
     }, {
         code: `import UNDERSCORE from "underscore"`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `import Underscore from "underscore"`
             }]
         }]
     }, {
         code: `import { exec as doEXEC } from "child_process"`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `import { exec as doExec } from "child_process"`
             }]
         }]
     }, {
         code: `export const MAX = 10;`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `export const Max = 10;`
             }]
         }]
     }, {
         code: `export let NOTCONST = 10;`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `export let Notconst = 10;`
             }]
         }]
     }, {
         code: `export var NOTCONST = 10;`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `export var Notconst = 10;`
             }]
         }]
@@ -404,7 +347,9 @@ es13RuleTester.run("strict-camel-case", strictCamelCaseRule, {
         code: `export let NOTCONST = 10;`,
         options: [{ ignoreSingleWordsIn: [ "first_class_constant" ] }],
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `export let Notconst = 10;`
             }]
         }]
@@ -412,34 +357,47 @@ es13RuleTester.run("strict-camel-case", strictCamelCaseRule, {
         code: `export var NOTCONST = 10;`,
         options: [{ ignoreSingleWordsIn: [ "first_class_constant" ] }],
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `export var Notconst = 10;`
             }]
         }]
     }, {
         code: `const esEnumDirection = { NORTH: 0, EAST: 1, SOUTH: 2, WEST: 3 }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `const esEnumDirection = { North: 0, EAST: 1, SOUTH: 2, WEST: 3 }`
             }]
         }, {
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `const esEnumDirection = { NORTH: 0, East: 1, SOUTH: 2, WEST: 3 }`
             }]
         }, {
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `const esEnumDirection = { NORTH: 0, EAST: 1, South: 2, WEST: 3 }`
             }]
         }, {
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `const esEnumDirection = { NORTH: 0, EAST: 1, SOUTH: 2, West: 3 }`
             }]
         }]
     }]
 });
 
-const tsRuleTester = new RuleTester({
-    parser: require.resolve('@typescript-eslint/parser')
+// tester for all selectors that only apply to TS source code
+const tsRuleTester = new EsLintRuleTester({
+    languageOptions: {
+        parser: { parse }
+    }
 });
 tsRuleTester.run("strict-camel-case", strictCamelCaseRule, {
     valid: [
@@ -463,42 +421,54 @@ tsRuleTester.run("strict-camel-case", strictCamelCaseRule, {
     invalid: [{
         code: `class MyClass { private innerHTML: string; }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class MyClass { private innerHtml: string; }`
             }]
         }]
     }, {
         code: `interface MyXMLInterface { xml: string; }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `interface MyXmlInterface { xml: string; }`
             }]
         }]
     }, {
         code: `interface MyInterface { innerHTML: string; }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `interface MyInterface { innerHtml: string; }`
             }]
         }]
     }, {
         code: `interface MyInterface { parseHTML(html: string): any; }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `interface MyInterface { parseHtml(html: string): any; }`
             }]
         }]
     }, {
         code: `type MyType = { someHTML: string }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `type MyType = { someHtml: string }`
             }]
         }]
     }, {
         code: `type MyType = { aBoolean: boolean, someHTML: string }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `type MyType = { aBoolean: boolean, someHtml: string }`
             }]
         }]
@@ -506,42 +476,170 @@ tsRuleTester.run("strict-camel-case", strictCamelCaseRule, {
         code: `enum HTMLTags { HEAD, BODY, DIV }`,
         options: [{ ignoredIdentifiers: ["HEAD", "BODY", "DIV"] }],
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `enum HtmlTags { HEAD, BODY, DIV }`
             }]
         }]
     }, {
         code: `enum Error { JSError }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `enum Error { JsError }`
             }]
         }]
     }, {
         code: `enum Direction { NORTH, EAST, SOUTH, WEST }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `enum Direction { North, EAST, SOUTH, WEST }`
             }]
         }, {
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `enum Direction { NORTH, East, SOUTH, WEST }`
             }]
         }, {
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `enum Direction { NORTH, EAST, South, WEST }`
             }]
         }, {
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `enum Direction { NORTH, EAST, SOUTH, West }`
             }]
         }]
     }, {
         code: `class Util { public static NAME = "TheUtil"; }`,
         errors: [{
+            messageId: "notCamelCaseWithSuggestion",
             suggestions: [{
+                messageId: "suggestionMessage",
                 output: `class Util { public static Name = "TheUtil"; }`
             }]
         }]
     }]
 });
+
+// without migrating all rule source code from the RuleModule types in eslint core to that of @typescript-eslint, the
+// following code rebuilds the rule as a @typescript-eslint RuleModule to use with TSESL's RuleTester
+type SccMessageIds = 
+    "notCamelCaseWithSuggestion" |
+    "notCamelCasePrivateWithSuggestion" |
+    "notCamelCaseNoSuggestion" |
+    "notCamelCasePrivateNoSuggestion" |
+    "suggestionMessage";
+const createRule = EsLintUtils.RuleCreator(
+    name => `https://github.com/adashrod/eslint-plugin-sequence/tree/main/src/docs/${name}`);
+const theRule = createRule({
+    name: "strict-camel-case",
+    defaultOptions: [],
+    // the schema of RuleModule in @typescript-eslint/utils and RuleModule in eslint are slightly different
+    // some janky casting, but it works because they're close enough
+    create: strictCamelCaseRule.create as unknown as EsLintUtils.RuleCreateAndOptions<unknown[], SccMessageIds>["create"],
+    meta: strictCamelCaseRule.meta as EsLintUtils.NamedCreateRuleMeta<SccMessageIds>
+});
+
+const ruleTesterEventEmitter = new EventEmitter();
+TsEsLintRuleTester.afterAll = () => {};
+TsEsLintRuleTester.it = function(text, method) {
+    ruleTesterEventEmitter.emit("it", text, method);
+    return method.call(this);
+};
+TsEsLintRuleTester.describe = function(text, method) {
+    ruleTesterEventEmitter.emit("describe", text, method);
+    return method.call(this);
+};
+// the suggestions in these test cases can't be verified using EsLintRuleTester because it parses the suggested output
+// and fails the test case if there are any errors, which happens when renaming identifiers and only applying one
+// suggestion at a time. Fortunately TsEsLintRuleTester isn't as strict
+// see https://github.com/eslint/eslint/pull/16639
+const tsEsRuleTester = new TsEsLintRuleTester();
+tsEsRuleTester.run("strict-camel-case", theRule , {
+    valid: [],
+    invalid: [{
+        code: `myXYZLabel1:
+my_label_2:
+for (let i = 0; i < 5; i++) {
+    if (i == 3) {
+        break my_label_2;
+    }
+}`,
+        errors: [{
+            messageId: "notCamelCaseWithSuggestion",
+            suggestions: [{
+                messageId: "suggestionMessage",
+                output: `myXyzLabel1:
+my_label_2:
+for (let i = 0; i < 5; i++) {
+    if (i == 3) {
+        break my_label_2;
+    }
+}`
+            }]
+        }, {
+            messageId: "notCamelCaseWithSuggestion",
+            suggestions: [{
+                messageId: "suggestionMessage",
+                output: `myXYZLabel1:
+myLabel2:
+for (let i = 0; i < 5; i++) {
+    if (i == 3) {
+        break my_label_2;
+    }
+}`
+            }]
+        }, {
+            messageId: "notCamelCaseWithSuggestion",
+            suggestions: [{
+                messageId: "suggestionMessage",
+                output: `myXYZLabel1:
+my_label_2:
+for (let i = 0; i < 5; i++) {
+    if (i == 3) {
+        break myLabel2;
+    }
+}`
+            }]
+        }]
+    }, {
+        code: `label_2:
+for (let i = 0; i < 5; i++) {
+    if (i == 3) {
+        continue label_2;
+    }
+}`,
+        errors: [{
+            messageId: "notCamelCaseWithSuggestion",
+            suggestions:[{
+                messageId: "suggestionMessage",
+                output: `label2:
+for (let i = 0; i < 5; i++) {
+    if (i == 3) {
+        continue label_2;
+    }
+}`
+            }]
+        }, {
+            messageId: "notCamelCaseWithSuggestion",
+            suggestions: [{
+                messageId: "suggestionMessage",
+                output: `label_2:
+for (let i = 0; i < 5; i++) {
+    if (i == 3) {
+        continue label2;
+    }
+}`
+            }]
+        }]
+    }]
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -24,9 +24,9 @@
         // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
 
         /* Modules */
-        "module": "CommonJs",                                /* Specify what module code is generated. */
+        "module": "Node16",                                /* Specify what module code is generated. */
         // "rootDir": "./src",                               /* Specify the root folder within your source files. */
-        "moduleResolution": "node",                          /* Specify how TypeScript looks up a file from a given module specifier. */
+        "moduleResolution": "node16",                          /* Specify how TypeScript looks up a file from a given module specifier. */
         "baseUrl": "./",                                     /* Specify the base directory to resolve non-relative module names. */
         "paths": {                                           /* Specify a set of entries that re-map imports to additional lookup locations. */
             "@adashrodEps/*": ["src/*"]


### PR DESCRIPTION
update packages to newer versions
- minor static typing changes to the rules to account for new node schemas
- add additional explicit "expected" values to unit tests since they're now required
- change tsconfig's module configs to support new packages
- change suggestion report schema to work with both eslint's RuleTester and https://github.com/typescript-eslint's

why ES5 test cases were removed from strict-camel-case unit tests:
- this error started happening after doing package upgrades
    - AssertionError [ERR_ASSERTION]: A fatal parsing error occurred: Parsing error: sourceType 'module' is not supported when ecmaVersion < 2015. Consider adding `{ ecmaVersion: 2015 }` to the parser options.
        - updating the ecmaVersion to >= 2015 is not an option, because these tests are explicitly for ECMA < 2015
        - manually specifying the `sourceType` property in the RuleTester config didn't fix it
        - trying to run these tests in a .cjs file didn't fix it
        - at this point, test cases that only apply to ES5 are irrelevant, so it's not worth maintaining

why some test cases in strict-camel-case now use @typescript-eslint/utils' RuleTester instead of eslint core's
- the package upgrades pulled in this new feature: https://github.com/eslint/eslint/pull/16639
- as a result, test cases that validate suggestions throw errors if the suggestion output has unresolved references due to renaming identifiers, which left me with two options:
    - major refactor of the suggestions to include fixes for all references, not just one at a time, thereby maintaining syntactic correctness when applying one
    - use a more lenient RuleTester