### PR TITLE
major version bump 1.0.0 with breaking changes

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -23,7 +23,6 @@ jobs:
         -   run: npm ci
         -   run: npm run lint
     unit_tests:
-
         runs-on: ubuntu-latest
 
         strategy:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Import rules can be used on ES6+ imports, as well as TypeScript imports
 ### [ordered-import-members](https://github.com/adashrod/eslint-plugin-sequence/tree/main/src/docs/ordered-import-members.md)
 (fixable): sort imported members by name
 ### [strict-camel-case](https://github.com/adashrod/eslint-plugin-sequence/tree/main/src/docs/strict-camel-case.md)
-(fixable via suggestions): enforce StrictCamelCase style, forbid LOOSECamelCase
+(fixable via suggestions): enforce StrictCamelCase style in identifiers, forbid LOOSECamelCase
 ### [logical-expression-complexity](https://github.com/adashrod/eslint-plugin-sequence/tree/main/src/docs/logical-expression-complexity.md)
 (*not* fixable): enforce limits on complexity of logical expressions
 
@@ -23,44 +23,49 @@ Import rules can be used on ES6+ imports, as well as TypeScript imports
 npm install --save-dev eslint-plugin-sequence
 ```
 
-Configure with EsLint, e.g. in `.eslintrc.json`
+Configure with EsLint, e.g. in `eslint.config.mjs`
 ```javascript
+import sequence from "eslint-plugin-sequence";
+
 ...
-"plugins": [
-    "sequence"
-],
-"rules": {
-    "sequence/ordered-imports-by-path": [
-        "error", {
-            "ignoreCase": true,
-            "sortSideEffectsFirst": true,
-            "allowSeparateGroups": true,
-            "sortTypeImportsFirst": true
-        }
-    ],
-    "sequence/ordered-import-members": [
-        "error", {
-            "ignoreCase": true,
-            "sortSpecifiersWithComments": true
-        }
-    ],
-    "sequence/strict-camel-case": [
-        "error", {
-            "ignoreImports": false,
-            "ignoredIdentifiers": ["legacyAPI", "htmlToXML", "PI", "TAU", "EPSILON"],
-            "allowOneCharWords": "last",
-            "ignoreSingleWordsIn": ["enum_member", "static_class_field"]
-        }
-    ],
-    "sequence/logical-expression-complexity": [
-        "error", {
-            "maxHeight": 3,
-            "maxTerms": 6,
-            "binaryOperators": ["==", "===", "!=", "!=="],
-            "includeTernary": true
-        }
-    ],
-    ...
-}
+
+        plugins: [
+            sequence
+        ],
+        rules: {
+            "sequence/ordered-imports-by-path": [
+                "error", {
+                    ignoreCase: true,
+                    sortSideEffectsFirst: true,
+                    allowSeparateGroups: true,
+                    sortTypeImportsFirst: true
+                }
+            ],
+            "sequence/ordered-import-members": [
+                "error", {
+                    ignoreCase: true,
+                    sortSpecifiersWithComments: true
+                }
+            ],
+            "sequence/strict-camel-case": [
+                "error", {
+                    ignoreImports: false,
+                    ignoredIdentifiers: ["legacyAPI", "htmlToXML", "PI", "TAU", "EPSILON"],
+                    allowOneCharWords: "last",
+                    ignoreSingleWordsIn: ["enum_member", "static_class_field"]
+                }
+            ],
+            "sequence/logical-expression-complexity": [
+                "error", {
+                    maxHeight: 3,
+                    maxTerms: 6,
+                    binaryOperators: ["==", "===", "!=", "!=="],
+                    includeTernary: true
+                }
+            ],
 ...
 ```
+
+## Compatibility
+
+As of version `1.0.0`, the plugin requires `eslint` peer `9.x`. To use with older versions of `eslint`, use version `0.7.0`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-sequence",
-    "version": "0.7.0",
+    "version": "1.0.0",
     "description": "A collection of EsLint rules variously related to sequences: import sorting, ordering, etc",
     "main": "index.js",
     "dependencies": {
@@ -21,6 +21,9 @@
         "ts-node": "^10.9.2",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.18.0"
+    },
+    "peerDependencies": {
+        "eslint": "9.x"
     },
     "scripts": {
         "test": "ts-node src/tests/test-all.ts",

--- a/src/docs/strict-camel-case.md
+++ b/src/docs/strict-camel-case.md
@@ -67,11 +67,9 @@ Further reading:
 "rules": {
     "sequence/strict-camel-case": [
         "error", {
-            "ignoreProperties": false,
             "ignoreImports": false,
             "ignoredIdentifiers": ["htmlToXML", "legacyAPI"],
             "allowOneCharWords": "last",
-            "ignoreSingleWords": false,
             "ignoreSingleWordsIn": ["enum_member", "static_class_field"]
         }
     ],
@@ -163,7 +161,7 @@ default: `[]`
 Identifiers that are all-caps and contain only one word are inherently ambiguous, e.g. `HTML, JSON, PI, TAU, EPSILON`. Any of these could be names of classes that are in loose camel case, or names of constants that are in all-caps snake case. There's no way to make that determination without knowing the semantic meaning of them.
 Adding additional words demontstrates how the single-word versions are ambiguous: `HTMLTags, JSONSerializer, TAU_IS_2_PI, EPSILON_UNCERTAINTY`.
 
-As opposed to `ignoreSingleWords`, which is very broad, this option lets you allow all-caps single words in certain contexts that are likely to have constant members. For example, you can allowlist 1st-class constants (`export const MAX = 10`) or static class fields (`class Util { public static MAX = 10; }`), but not identifiers that are not usually used as constants (`class API {}` or `type HTML = {...}`).
+This option lets you allow all-caps single words in certain contexts that are likely to have constant members. For example, you can allowlist 1st-class constants (`export const MAX = 10`) or static class fields (`class Util { public static MAX = 10; }`), but not identifiers that are *not* usually used as constants (`class API {}` or `type HTML = {...}`).
 
 #### Example allowed single-word identifiers with each option:
 
@@ -197,52 +195,3 @@ class MyUtil {
     public static VERSION = "1.0";
 }
 ```
-
-## ignoreProperties (deprecated)
-
-type: `boolean`
-
-default: `false`
-
-#### This option will be removed in a future release. Please use `ignoredIdentifiers` and/or `ignoreSingleWordsIn` instead
-
-Set to `true` to ignore: class fields, class methods, object keys, object methods, and private fields and methods.
-
-Example items that are ignored:
-```javascript
-let obj = {
-    ignoredKey: 10,
-    ignoredFunction() {}
-};
-
-class MyJsClass {
-    constructor() {
-        this.ignoredProperty = "";
-    }
-    ignoredFunction() {}
-    #ignoredPrivateField = 5;
-    #ignoredPrivateFunction() {}
-}
-
-class MyTsClass {
-    public ignoredField: string = "";
-}
-```
-
-## ignoreSingleWords (deprecated)
----
-
-type: `boolean`
-
-default: `false`
-
-#### This option will be removed in a future release. Please use `ignoredIdentifiers` and/or `ignoreSingleWordsIn` instead
-
-Identifiers that are all-caps and contain only one word are inherently ambiguous, e.g. `HTML, JSON, PI, TAU, EPSILON`. Any of these could be names of classes that are in loose camel case, or names of constants that are in all-caps snake case. There's no way to make that determination without knowing the semantic meaning of them.
-Adding additional words demontstrates how the single-word versions are ambiguous: `HTMLTags, JSONSerializer, TAU_IS_2_PI, EPSILON_UNCERTAINTY`.
-
-`true`: all-caps single-word identifiers are ignored and don't trigger errors (assumed to be all-caps snake case, i.e. constants)
-
-`false`: all-caps single-word identifiers trigger errors (assumed to be loose camel case)
-
-If you'd like to enforce `strict-camel-case` on single-word identifiers, but not trigger errors for single-word all-caps constants, ~~consider keeping this option set to `false` and either adding your constant names to the `ignoredIdentifiers` option, or using `/* eslint-disable sequence/strict-camel-case */` around your constants.~~ use `ignoreSingleWordsIn` to specify how you are using constants or put your identifiers in `ignoredIdentifiers`.

--- a/src/lib/rules/ordered-import-members.ts
+++ b/src/lib/rules/ordered-import-members.ts
@@ -60,8 +60,7 @@ type GenericSpecifier = ImportSpecifier | ImportDefaultSpecifier | ImportNamespa
 
 function create(context: Rule.RuleContext): Rule.RuleListener {
     const cfg = initializeConfig(context.options, DEFAULT_PROPERTIES),
-        // context.getSourceCode() is deprecated, but context.sourceCode is always undefined in older eslint
-        sourceCode = context.sourceCode ?? context.getSourceCode();
+        sourceCode = context.sourceCode;
 
     /**
      * Comparares ImportSpecifiers by name, honoring the value of ignoreCase

--- a/src/lib/rules/ordered-imports-by-path.ts
+++ b/src/lib/rules/ordered-imports-by-path.ts
@@ -73,8 +73,7 @@ type TypeCapableImportDeclaration = ImportDeclaration & {
 
 function create(context: Rule.RuleContext): Rule.RuleListener {
     const cfg = initializeConfig(context.options, DEFAULT_PROPERTIES),
-        // context.getSourceCode() is deprecated, but context.sourceCode is always undefined in older eslint
-        sourceCode = context.sourceCode ?? context.getSourceCode();
+        sourceCode = context.sourceCode;
 
     /**
      * for comparing to current node

--- a/src/tests/rules/strict-camel-case.ts
+++ b/src/tests/rules/strict-camel-case.ts
@@ -34,9 +34,6 @@ describe("strict-camel-case ES", () => {
                 }, {
                     code: `const getX = () => {};`,
                     options: [{ allowOneCharWords: "last" }]
-                }, {
-                    code: `class API {}`,
-                    options: [{ ignoreSingleWords: true }]
                 },
                 `const apiApiApi = "...";`,
                 `const someFunc = (firstParam, secondParam) => {};`,
@@ -47,9 +44,6 @@ describe("strict-camel-case ES", () => {
                 `try { throw new Error(); } catch (anIoException) {}`,
                 `let obj = { htmlApi: "..." }`,
                 {
-                    code: `let obj = { htmlAPI: "..." };`,
-                    options: [{ ignoreProperties: true }]
-                }, {
                     code: `let JSONAPI = {}, xmlApi = {};`,
                     options: [{ ignoredIdentifiers: ["JSONAPI"] }]
                 },
@@ -156,7 +150,6 @@ describe("strict-camel-case ES", () => {
                 }]
             }, {
                 code: `class API {}`,
-                options: [{ ignoreSingleWords: false }],
                 errors: [{
                     messageId: "notCamelCaseWithSuggestion",
                     suggestions: [{


### PR DESCRIPTION
remove deprecated options `ignoreProperties` and `ignoreSingleWords` from `strict-camel-case` rule in favor of `ignoreSingleWordsIn` option

remove usages of deprecated EsLint APIs that were removed in 9 or will be removed in 10, and require peer dependency of eslint 9.x