### PR TITLE
new config option for ordered-imports-by-path: groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,16 +31,21 @@ import sequence from "eslint-plugin-sequence";
 
 ...
 
-        plugins: [
+        plugins: {
             sequence
-        ],
+        },
         rules: {
             "sequence/ordered-imports-by-path": [
                 "error", {
                     ignoreCase: true,
                     sortSideEffectsFirst: true,
                     allowSeparateGroups: true,
-                    sortTypeImportsFirst: true
+                    sortTypeImportsFirst: true,
+                    groups: [
+                        "node:.*",
+                        "the_rest",
+                        "@myApp/.*"
+                    ]
                 }
             ],
             "sequence/ordered-import-members": [

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -78,7 +78,7 @@ export default [
                     natural: true,
                 },
             ],
-        
+
             "@stylistic/ts/brace-style": ["error", "1tbs", {
                 allowSingleLine: true,
             }],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "eslint-plugin-sequence",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "eslint-plugin-sequence",
-            "version": "1.1.2",
+            "version": "1.2.0",
             "license": "ISC",
             "dependencies": {
                 "module-alias": "^2.2.3",
@@ -24,7 +24,7 @@
                 "@typescript-eslint/rule-tester": "^8.18.0",
                 "eslint": "^9.17.0",
                 "eslint-plugin-no-relative-import-paths": "^1.6.1",
-                "eslint-plugin-sequence": "^1.1.1",
+                "eslint-plugin-sequence": "^1.1.2",
                 "ts-node": "^10.9.2",
                 "typescript": "^5.7.2",
                 "typescript-eslint": "^8.18.0"
@@ -47,9 +47,9 @@
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.4.1.tgz",
-            "integrity": "sha512-s3O3waFUrMV8P/XaF/+ZTp1X9XBZW1a4B97ZnjQF2KYWaFD2A8KyFBsrsfSjEmjn3RGWAIuvlneuZm3CUK3jbA==",
+            "version": "4.9.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/eslint-utils/-/eslint-utils-4.9.0.tgz",
+            "integrity": "sha512-ayVFHdtZ+hsq1t2Dy24wCmGXGe4q9Gu3smhLYALJrr473ZH27MsnSL+LKUlimp4BWJqMDMLmPpx/Q9R3OAlL4g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -89,16 +89,19 @@
             }
         },
         "node_modules/@eslint/compat": {
-            "version": "1.2.4",
-            "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.2.4.tgz",
-            "integrity": "sha512-S8ZdQj/N69YAtuqFt7653jwcvuUj131+6qGLUyDqfDg1OIoBQ66OCuXC473YQfO2AaxITTutiRQiDwoo7ZLYyg==",
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/compat/-/compat-1.4.0.tgz",
+            "integrity": "sha512-DEzm5dKeDBPm3r08Ixli/0cmxr8LkRdwxMRUIJBlSCpAwSrvFEJpVBzV+66JhDxiaqKxnRzCXhtiMiczF7Hglg==",
             "dev": true,
             "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.16.0"
+            },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
             "peerDependencies": {
-                "eslint": "^9.10.0"
+                "eslint": "^8.40 || 9"
             },
             "peerDependenciesMeta": {
                 "eslint": {
@@ -107,13 +110,13 @@
             }
         },
         "node_modules/@eslint/config-array": {
-            "version": "0.19.1",
-            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.1.tgz",
-            "integrity": "sha512-fo6Mtm5mWyKjA/Chy1BYTdn5mGJoDNjC7C64ug20ADsRDGrA85bN3uK3MaKbeRkRuuIEAR5N33Jr1pbm411/PA==",
+            "version": "0.21.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
+            "integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
-                "@eslint/object-schema": "^2.1.5",
+                "@eslint/object-schema": "^2.1.6",
                 "debug": "^4.3.1",
                 "minimatch": "^3.1.2"
             },
@@ -122,9 +125,9 @@
             }
         },
         "node_modules/@eslint/config-array/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -145,10 +148,23 @@
                 "node": "*"
             }
         },
+        "node_modules/@eslint/config-helpers": {
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.0.tgz",
+            "integrity": "sha512-WUFvV4WoIwW8Bv0KeKCIIEgdSiFOsulyN0xrMu+7z43q/hkOLXjvb5u7UC9jDxvRzcrbEmuZBX5yJZz1741jog==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@eslint/core": "^0.16.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            }
+        },
         "node_modules/@eslint/core": {
-            "version": "0.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.9.1.tgz",
-            "integrity": "sha512-GuUdqkyyzQI5RMIWkHhvTWLCyLo1jNK3vzkSyaExH5kHPDHcuL2VOpHjmMY+y3+NC69qAKToBqldTBgYeLSr9Q==",
+            "version": "0.16.0",
+            "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.16.0.tgz",
+            "integrity": "sha512-nmC8/totwobIiFcGkDza3GIKfAw1+hLiYVrh3I1nIomQ8PEr5cxg34jnkmGawul/ep52wGRAcyeDCNtWKSOj4Q==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
@@ -159,9 +175,9 @@
             }
         },
         "node_modules/@eslint/eslintrc": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.2.0.tgz",
-            "integrity": "sha512-grOjVNN8P3hjJn/eIETF1wwd12DdnwFDoyceUJLYYdkpbwq3nLi+4fqrTAONx7XDALqlL220wC/RHSC/QTI/0w==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
+            "integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -183,9 +199,9 @@
             }
         },
         "node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -207,19 +223,22 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "9.17.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
-            "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
+            "version": "9.37.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.37.0.tgz",
+            "integrity": "sha512-jaS+NJ+hximswBG6pjNX0uEJZkrT0zwpVi3BA3vX22aFGjJjmgSTSmPpZCRKmoBL5VY/M6p0xsSJx7rk7sy5gg==",
             "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "url": "https://eslint.org/donate"
             }
         },
         "node_modules/@eslint/object-schema": {
-            "version": "2.1.5",
-            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.5.tgz",
-            "integrity": "sha512-o0bhxnL89h5Bae5T318nFoFzGy+YE5i/gGkoPAgkmTVdRKTiv3p8JHevPiPaMwoloKfEiiaHlawCqaZMqRm+XQ==",
+            "version": "2.1.6",
+            "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
+            "integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -227,12 +246,13 @@
             }
         },
         "node_modules/@eslint/plugin-kit": {
-            "version": "0.2.4",
-            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.4.tgz",
-            "integrity": "sha512-zSkKow6H5Kdm0ZUQUB2kV5JIXqoG0+uH5YADhaEHswm664N9Db8dXSi0nMJpacpMf+MyyglF1vnZohpEg5yUtg==",
+            "version": "0.4.0",
+            "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.0.tgz",
+            "integrity": "sha512-sB5uyeq+dwCWyPi31B2gQlVlo+j5brPlWx4yZBrEaRo/nhdDE8Xke1gsGgtiBdaBTxuTkceLVuVt/pclrasb0A==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
+                "@eslint/core": "^0.16.0",
                 "levn": "^0.4.1"
             },
             "engines": {
@@ -250,31 +270,17 @@
             }
         },
         "node_modules/@humanfs/node": {
-            "version": "0.16.6",
-            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-            "integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
+            "version": "0.16.7",
+            "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
+            "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
             "dev": true,
             "license": "Apache-2.0",
             "dependencies": {
                 "@humanfs/core": "^0.19.1",
-                "@humanwhocodes/retry": "^0.3.0"
+                "@humanwhocodes/retry": "^0.4.0"
             },
             "engines": {
                 "node": ">=18.18.0"
-            }
-        },
-        "node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
-            "version": "0.3.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-            "integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
-            "dev": true,
-            "license": "Apache-2.0",
-            "engines": {
-                "node": ">=18.18"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/nzakas"
             }
         },
         "node_modules/@humanwhocodes/module-importer": {
@@ -292,9 +298,9 @@
             }
         },
         "node_modules/@humanwhocodes/retry": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.1.tgz",
-            "integrity": "sha512-c7hNEllBlenFTHBky65mhq8WD2kbN9Q6gk0bTk8lSBvc554jpXSkST1iePudpt7+A/AQvuHs9EMqjHDXMY1lrA==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
+            "integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -316,9 +322,9 @@
             }
         },
         "node_modules/@jridgewell/sourcemap-codec": {
-            "version": "1.5.0",
-            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
-            "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==",
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+            "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
             "dev": true,
             "license": "MIT"
         },
@@ -372,9 +378,9 @@
             }
         },
         "node_modules/@stylistic/eslint-plugin-ts": {
-            "version": "2.12.1",
-            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.12.1.tgz",
-            "integrity": "sha512-Xx1NIioeW6LLlOfq5L/dLSrUXvi6q80UXDNbn/rXjKCzFT4a8wKwtp1q25kssdr1JEXI9a6tOHwFsh4Em+MoGg==",
+            "version": "2.13.0",
+            "resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin-ts/-/eslint-plugin-ts-2.13.0.tgz",
+            "integrity": "sha512-nooe1oTwz60T4wQhZ+5u0/GAu3ygkKF9vPPZeRn/meG71ntQ0EZXVOKEonluAYl/+CV2T+nN0dknHa4evAW13Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -429,9 +435,9 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-            "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw==",
+            "version": "1.0.8",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+            "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
             "dev": true,
             "license": "MIT"
         },
@@ -450,13 +456,13 @@
             "license": "MIT"
         },
         "node_modules/@types/node": {
-            "version": "22.10.5",
-            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.5.tgz",
-            "integrity": "sha512-F8Q+SeGimwOo86fiovQh8qiXfFEh2/ocYv7tU5pJ3EXMSSxk1Joj5wefpFK2fHTf/N6HKGSxIDBT9f3gCxXPkQ==",
+            "version": "22.18.8",
+            "resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.8.tgz",
+            "integrity": "sha512-pAZSHMiagDR7cARo/cch1f3rXy0AEXwsVsVH09FcyeJVAzCnGgmYis7P3JidtTUjyadhTeSo8TgRPswstghDaw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "undici-types": "~6.20.0"
+                "undici-types": "~6.21.0"
             }
         },
         "node_modules/@types/string-natural-compare": {
@@ -467,21 +473,21 @@
             "license": "MIT"
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.19.0.tgz",
-            "integrity": "sha512-NggSaEZCdSrFddbctrVjkVZvFC6KGfKfNK0CU7mNK/iKHGKbzT4Wmgm08dKpcZECBu9f5FypndoMyRHkdqfT1Q==",
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.45.0.tgz",
+            "integrity": "sha512-HC3y9CVuevvWCl/oyZuI47dOeDF9ztdMEfMH8/DW/Mhwa9cCLnK1oD7JoTVGW/u7kFzNZUKUoyJEqkaJh5y3Wg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.10.0",
-                "@typescript-eslint/scope-manager": "8.19.0",
-                "@typescript-eslint/type-utils": "8.19.0",
-                "@typescript-eslint/utils": "8.19.0",
-                "@typescript-eslint/visitor-keys": "8.19.0",
+                "@typescript-eslint/scope-manager": "8.45.0",
+                "@typescript-eslint/type-utils": "8.45.0",
+                "@typescript-eslint/utils": "8.45.0",
+                "@typescript-eslint/visitor-keys": "8.45.0",
                 "graphemer": "^1.4.0",
-                "ignore": "^5.3.1",
+                "ignore": "^7.0.0",
                 "natural-compare": "^1.4.0",
-                "ts-api-utils": "^1.3.0"
+                "ts-api-utils": "^2.1.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -491,22 +497,32 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "^8.0.0 || ^8.0.0-alpha.0",
+                "@typescript-eslint/parser": "^8.45.0",
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+            "version": "7.0.5",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+            "integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.19.0.tgz",
-            "integrity": "sha512-6M8taKyOETY1TKHp0x8ndycipTVgmp4xtg5QpEZzXxDhNvvHOJi5rLRkLr8SK3jTgD5l4fTlvBiRdfsuWydxBw==",
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.45.0.tgz",
+            "integrity": "sha512-TGf22kon8KW+DeKaUmOibKWktRY8b2NSAZNdtWh798COm1NWx8+xJ6iFBtk3IvLdv6+LGLJLRlyhrhEDZWargQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.19.0",
-                "@typescript-eslint/types": "8.19.0",
-                "@typescript-eslint/typescript-estree": "8.19.0",
-                "@typescript-eslint/visitor-keys": "8.19.0",
+                "@typescript-eslint/scope-manager": "8.45.0",
+                "@typescript-eslint/types": "8.45.0",
+                "@typescript-eslint/typescript-estree": "8.45.0",
+                "@typescript-eslint/visitor-keys": "8.45.0",
                 "debug": "^4.3.4"
             },
             "engines": {
@@ -518,18 +534,41 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
-        "node_modules/@typescript-eslint/rule-tester": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.19.0.tgz",
-            "integrity": "sha512-wLTQopSNqT/ayzo6i5gzXtud4UM49DsXshGzsYAPwbR8itgTGkdZ5qVfLYfbve9zQpEsaoTpoTrBabPOqCPlJQ==",
+        "node_modules/@typescript-eslint/project-service": {
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.45.0.tgz",
+            "integrity": "sha512-3pcVHwMG/iA8afdGLMuTibGR7pDsn9RjDev6CCB+naRsSYs2pns5QbinF4Xqw6YC/Sj3lMrm/Im0eMfaa61WUg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.19.0",
-                "@typescript-eslint/utils": "8.19.0",
+                "@typescript-eslint/tsconfig-utils": "^8.45.0",
+                "@typescript-eslint/types": "^8.45.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
+        "node_modules/@typescript-eslint/rule-tester": {
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.45.0.tgz",
+            "integrity": "sha512-o0Tn3Vw6hliTsnVITONI+TK/VA22agA+Zyk4pKg98sWy6RXIl7srW3zDOjdtdHUuk8FpzCUBtbQCtXH/2VeLtQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/parser": "8.45.0",
+                "@typescript-eslint/typescript-estree": "8.45.0",
+                "@typescript-eslint/utils": "8.45.0",
                 "ajv": "^6.12.6",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "lodash.merge": "4.6.2",
@@ -547,14 +586,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.19.0.tgz",
-            "integrity": "sha512-hkoJiKQS3GQ13TSMEiuNmSCvhz7ujyqD1x3ShbaETATHrck+9RaDdUbt+osXaUuns9OFwrDTTrjtwsU8gJyyRA==",
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.45.0.tgz",
+            "integrity": "sha512-clmm8XSNj/1dGvJeO6VGH7EUSeA0FMs+5au/u3lrA3KfG8iJ4u8ym9/j2tTEoacAffdW1TVUzXO30W1JTJS7dA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.19.0",
-                "@typescript-eslint/visitor-keys": "8.19.0"
+                "@typescript-eslint/types": "8.45.0",
+                "@typescript-eslint/visitor-keys": "8.45.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -564,17 +603,35 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.45.0.tgz",
+            "integrity": "sha512-aFdr+c37sc+jqNMGhH+ajxPXwjv9UtFZk79k8pLoJ6p4y0snmYpPA52GuWHgt2ZF4gRRW6odsEj41uZLojDt5w==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.0.0"
+            }
+        },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.19.0.tgz",
-            "integrity": "sha512-TZs0I0OSbd5Aza4qAMpp1cdCYVnER94IziudE3JU328YUHgWu9gwiwhag+fuLeJ2LkWLXI+F/182TbG+JaBdTg==",
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.45.0.tgz",
+            "integrity": "sha512-bpjepLlHceKgyMEPglAeULX1vixJDgaKocp0RVJ5u4wLJIMNuKtUXIczpJCPcn2waII0yuvks/5m5/h3ZQKs0A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/typescript-estree": "8.19.0",
-                "@typescript-eslint/utils": "8.19.0",
+                "@typescript-eslint/types": "8.45.0",
+                "@typescript-eslint/typescript-estree": "8.45.0",
+                "@typescript-eslint/utils": "8.45.0",
                 "debug": "^4.3.4",
-                "ts-api-utils": "^1.3.0"
+                "ts-api-utils": "^2.1.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -585,13 +642,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.19.0.tgz",
-            "integrity": "sha512-8XQ4Ss7G9WX8oaYvD4OOLCjIQYgRQxO+qCiR2V2s2GxI9AUpo7riNwo6jDhKtTcaJjT8PY54j2Yb33kWtSJsmA==",
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.45.0.tgz",
+            "integrity": "sha512-WugXLuOIq67BMgQInIxxnsSyRLFxdkJEJu8r4ngLR56q/4Q5LrbfkFRH27vMTjxEK8Pyz7QfzuZe/G15qQnVRA==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -603,20 +660,22 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.19.0.tgz",
-            "integrity": "sha512-WW9PpDaLIFW9LCbucMSdYUuGeFUz1OkWYS/5fwZwTA+l2RwlWFdJvReQqMUMBw4yJWJOfqd7An9uwut2Oj8sLw==",
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.45.0.tgz",
+            "integrity": "sha512-GfE1NfVbLam6XQ0LcERKwdTTPlLvHvXXhOeUGC1OXi4eQBoyy1iVsW+uzJ/J9jtCz6/7GCQ9MtrQ0fml/jWCnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.19.0",
-                "@typescript-eslint/visitor-keys": "8.19.0",
+                "@typescript-eslint/project-service": "8.45.0",
+                "@typescript-eslint/tsconfig-utils": "8.45.0",
+                "@typescript-eslint/types": "8.45.0",
+                "@typescript-eslint/visitor-keys": "8.45.0",
                 "debug": "^4.3.4",
                 "fast-glob": "^3.3.2",
                 "is-glob": "^4.0.3",
                 "minimatch": "^9.0.4",
                 "semver": "^7.6.0",
-                "ts-api-utils": "^1.3.0"
+                "ts-api-utils": "^2.1.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -626,20 +685,20 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.19.0.tgz",
-            "integrity": "sha512-PTBG+0oEMPH9jCZlfg07LCB2nYI0I317yyvXGfxnvGvw4SHIOuRnQ3kadyyXY6tGdChusIHIbM5zfIbp4M6tCg==",
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.45.0.tgz",
+            "integrity": "sha512-bxi1ht+tLYg4+XV2knz/F7RVhU0k6VrSMc9sb8DQ6fyCTrGQLHfo7lDtN0QJjZjKkLA2ThrKuCdHEvLReqtIGg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.4.0",
-                "@typescript-eslint/scope-manager": "8.19.0",
-                "@typescript-eslint/types": "8.19.0",
-                "@typescript-eslint/typescript-estree": "8.19.0"
+                "@eslint-community/eslint-utils": "^4.7.0",
+                "@typescript-eslint/scope-manager": "8.45.0",
+                "@typescript-eslint/types": "8.45.0",
+                "@typescript-eslint/typescript-estree": "8.45.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -650,18 +709,18 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.19.0.tgz",
-            "integrity": "sha512-mCFtBbFBJDCNCWUl5y6sZSCHXw1DEFEk3c/M3nRK2a4XUB8StGFtmcEMizdjKuBzB6e/smJAAWYug3VrdLMr1w==",
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.45.0.tgz",
+            "integrity": "sha512-qsaFBA3e09MIDAGFUrTk+dzqtfv1XPVz8t8d1f0ybTzrCY7BKiMC5cjrl1O/P7UmHsNyW90EYSkU/ZWpmXelag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.19.0",
-                "eslint-visitor-keys": "^4.2.0"
+                "@typescript-eslint/types": "8.45.0",
+                "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -672,9 +731,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.14.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-            "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+            "version": "8.15.0",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
+            "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
             "bin": {
@@ -762,9 +821,9 @@
             "license": "MIT"
         },
         "node_modules/brace-expansion": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
-            "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.2.tgz",
+            "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -861,9 +920,9 @@
             }
         },
         "node_modules/debug": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
-            "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+            "version": "4.4.3",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+            "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -909,22 +968,23 @@
             }
         },
         "node_modules/eslint": {
-            "version": "9.17.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
-            "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
+            "version": "9.37.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.37.0.tgz",
+            "integrity": "sha512-XyLmROnACWqSxiGYArdef1fItQd47weqB7iwtfr9JHwRrqIXZdcFMvvEcL9xHCmL0SNsOvF0c42lWyM1U5dgig==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@eslint-community/eslint-utils": "^4.2.0",
+                "@eslint-community/eslint-utils": "^4.8.0",
                 "@eslint-community/regexpp": "^4.12.1",
-                "@eslint/config-array": "^0.19.0",
-                "@eslint/core": "^0.9.0",
-                "@eslint/eslintrc": "^3.2.0",
-                "@eslint/js": "9.17.0",
-                "@eslint/plugin-kit": "^0.2.3",
+                "@eslint/config-array": "^0.21.0",
+                "@eslint/config-helpers": "^0.4.0",
+                "@eslint/core": "^0.16.0",
+                "@eslint/eslintrc": "^3.3.1",
+                "@eslint/js": "9.37.0",
+                "@eslint/plugin-kit": "^0.4.0",
                 "@humanfs/node": "^0.16.6",
                 "@humanwhocodes/module-importer": "^1.0.1",
-                "@humanwhocodes/retry": "^0.4.1",
+                "@humanwhocodes/retry": "^0.4.2",
                 "@types/estree": "^1.0.6",
                 "@types/json-schema": "^7.0.15",
                 "ajv": "^6.12.4",
@@ -932,9 +992,9 @@
                 "cross-spawn": "^7.0.6",
                 "debug": "^4.3.2",
                 "escape-string-regexp": "^4.0.0",
-                "eslint-scope": "^8.2.0",
-                "eslint-visitor-keys": "^4.2.0",
-                "espree": "^10.3.0",
+                "eslint-scope": "^8.4.0",
+                "eslint-visitor-keys": "^4.2.1",
+                "espree": "^10.4.0",
                 "esquery": "^1.5.0",
                 "esutils": "^2.0.2",
                 "fast-deep-equal": "^3.1.3",
@@ -976,9 +1036,9 @@
             "license": "ISC"
         },
         "node_modules/eslint-plugin-sequence": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/eslint-plugin-sequence/-/eslint-plugin-sequence-1.1.1.tgz",
-            "integrity": "sha512-1wN55NI14mn9PM5cPGt775xbsB3iQOH0S9OGIKnKUt4KGpa/b0/Olk23yEO2in3/y8C2dcKHtwbXkfP6kdjc0w==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-sequence/-/eslint-plugin-sequence-1.1.2.tgz",
+            "integrity": "sha512-IH1IIcP+32GZRwFnnGBYGvjepMC8mbRISMdJ3F51XsiK3wfUHIj16FWGo10PXleUEB20Gk657X71Cf/YRO04Kg==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -990,9 +1050,9 @@
             }
         },
         "node_modules/eslint-scope": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.2.0.tgz",
-            "integrity": "sha512-PHlWUfG6lvPc3yvP5A4PNyBL1W8fkDUccmI21JUu/+GKZBoH/W5u6usENXUrWFRsyoW5ACUjFGgAFQp5gUlb/A==",
+            "version": "8.4.0",
+            "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
+            "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
@@ -1007,9 +1067,9 @@
             }
         },
         "node_modules/eslint-visitor-keys": {
-            "version": "4.2.0",
-            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.0.tgz",
-            "integrity": "sha512-UyLnSehNt62FFhSwjZlHmeokpRK59rcz29j+F1/aDgbkbRTk7wIc9XzdoasMUbRNKDM0qQt/+BJ4BrpFeABemw==",
+            "version": "4.2.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
+            "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
             "engines": {
@@ -1020,9 +1080,9 @@
             }
         },
         "node_modules/eslint/node_modules/brace-expansion": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
-            "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+            "version": "1.1.12",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+            "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1044,15 +1104,15 @@
             }
         },
         "node_modules/espree": {
-            "version": "10.3.0",
-            "resolved": "https://registry.npmjs.org/espree/-/espree-10.3.0.tgz",
-            "integrity": "sha512-0QYC8b24HWY8zjRnDTL6RiHfDbAWn63qb4LMj1Z4b076A4une81+z03Kg7l7mn/48PUTqoLptSXez8oknU8Clg==",
+            "version": "10.4.0",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
+            "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
             "dev": true,
             "license": "BSD-2-Clause",
             "dependencies": {
-                "acorn": "^8.14.0",
+                "acorn": "^8.15.0",
                 "acorn-jsx": "^5.3.2",
-                "eslint-visitor-keys": "^4.2.0"
+                "eslint-visitor-keys": "^4.2.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1159,9 +1219,9 @@
             "license": "MIT"
         },
         "node_modules/fastq": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.18.0.tgz",
-            "integrity": "sha512-QKHXPW0hD8g4UET03SdOdunzSouc9N4AuHdsX8XNcTsuz+yYFILVNIX4l9yHABMhiEI9Db0JTTIpu0wB+Y1QQw==",
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
+            "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
             "dev": true,
             "license": "ISC",
             "dependencies": {
@@ -1226,9 +1286,9 @@
             }
         },
         "node_modules/flatted": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.2.tgz",
-            "integrity": "sha512-AiwGJM8YcNOaobumgtng+6NHuOqC3A7MixFeDafM3X9cIUM+xUXoS5Vfgf+OihAYe20fxqNM9yPBXJzRtZ/4eA==",
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
+            "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
             "dev": true,
             "license": "ISC"
         },
@@ -1286,9 +1346,9 @@
             }
         },
         "node_modules/import-fresh": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
-            "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
+            "version": "3.3.1",
+            "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+            "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
@@ -1648,9 +1708,9 @@
             }
         },
         "node_modules/reusify": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+            "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1683,9 +1743,9 @@
             }
         },
         "node_modules/semver": {
-            "version": "7.6.3",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.3.tgz",
-            "integrity": "sha512-oVekP1cKtI+CTDvHWYFUcMtsK/00wmAEfyqKfNdARm8u1wNVhSgaX7A8d4UuIlUI5e84iEwOhs7ZPYRmzU9U6A==",
+            "version": "7.7.2",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+            "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
             "dev": true,
             "license": "ISC",
             "bin": {
@@ -1764,16 +1824,16 @@
             }
         },
         "node_modules/ts-api-utils": {
-            "version": "1.4.3",
-            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
-            "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
+            "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
             "dev": true,
             "license": "MIT",
             "engines": {
-                "node": ">=16"
+                "node": ">=18.12"
             },
             "peerDependencies": {
-                "typescript": ">=4.2.0"
+                "typescript": ">=4.8.4"
             }
         },
         "node_modules/ts-node": {
@@ -1834,9 +1894,9 @@
             }
         },
         "node_modules/typescript": {
-            "version": "5.7.2",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
-            "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
             "dev": true,
             "license": "Apache-2.0",
             "bin": {
@@ -1848,15 +1908,16 @@
             }
         },
         "node_modules/typescript-eslint": {
-            "version": "8.19.0",
-            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.19.0.tgz",
-            "integrity": "sha512-Ni8sUkVWYK4KAcTtPjQ/UTiRk6jcsuDhPpxULapUDi8A/l8TSBk+t1GtJA1RsCzIJg0q6+J7bf35AwQigENWRQ==",
+            "version": "8.45.0",
+            "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.45.0.tgz",
+            "integrity": "sha512-qzDmZw/Z5beNLUrXfd0HIW6MzIaAV5WNDxmMs9/3ojGOpYavofgNAAD/nC6tGV2PczIi0iw8vot2eAe/sBn7zg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/eslint-plugin": "8.19.0",
-                "@typescript-eslint/parser": "8.19.0",
-                "@typescript-eslint/utils": "8.19.0"
+                "@typescript-eslint/eslint-plugin": "8.45.0",
+                "@typescript-eslint/parser": "8.45.0",
+                "@typescript-eslint/typescript-estree": "8.45.0",
+                "@typescript-eslint/utils": "8.45.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1867,13 +1928,13 @@
             },
             "peerDependencies": {
                 "eslint": "^8.57.0 || ^9.0.0",
-                "typescript": ">=4.8.4 <5.8.0"
+                "typescript": ">=4.8.4 <6.0.0"
             }
         },
         "node_modules/undici-types": {
-            "version": "6.20.0",
-            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
-            "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
+            "version": "6.21.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+            "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "dev": true,
             "license": "MIT"
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "eslint-plugin-sequence",
-    "version": "1.1.2",
+    "version": "1.2.0",
     "description": "A collection of EsLint rules variously related to sequences: import sorting, ordering, etc",
     "main": "index.js",
     "dependencies": {
@@ -19,7 +19,7 @@
         "@typescript-eslint/rule-tester": "^8.18.0",
         "eslint": "^9.17.0",
         "eslint-plugin-no-relative-import-paths": "^1.6.1",
-        "eslint-plugin-sequence": "^1.1.1",
+        "eslint-plugin-sequence": "^1.1.2",
         "ts-node": "^10.9.2",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.18.0"

--- a/src/docs/ordered-imports-by-path.md
+++ b/src/docs/ordered-imports-by-path.md
@@ -59,6 +59,64 @@ In the above example, the two groups of imports are each sorted separately.
 
 `false`: grouping is ignored and all imports are sorted as a single collection of imports
 
+## groups
+---------
+
+type: `string[]`
+
+default: `[]`
+
+Each string is a regular expression to match import path/package names. One special value is `THE_REST`. Each regex corresponds to a group of imports matching that regex, with groups separated by an additional line break. The token `THE_REST` *must* be present in the `groups` array; if it's missing, then this option is ignored. If using `sortSideEffectsFirst: true`, then those imports will implicitly be put into a first group called `SIDE_EFFECTS`.
+
+Example:
+```
+    // eslint config
+    groups: [
+        "node:.*",
+        "THE_REST",
+        "app/.*"
+    ]
+```
+
+```
+// compliant code
+import process from "node:process";
+import { clearTimeout, setTimeout } from "node:timers";
+
+import { Logger } from "simple-node-logger";
+import yargs from "yargs/yargs";
+
+import User from "app/model/User"
+import User from "app/model/Article"
+```
+
+Example with side-effects imports:
+```
+    // eslint config
+    sortSideEffectsFirst: true,
+    groups: [
+        "node:.*",
+        "THE_REST",
+        "app/.*"
+    ]
+```
+
+```
+// compliant code
+import "module-alias/register";
+
+import process from "node:process";
+import { clearTimeout, setTimeout } from "node:timers";
+
+import { Logger } from "simple-node-logger";
+import yargs from "yargs/yargs";
+
+import User from "app/model/User"
+import User from "app/model/Article"
+```
+
+All package names in the first group - `node:process`, `node:timers` - match the first regex, `node:.*`. All path names in the third group - `app/model/User`, `app/model/Article` - match the third regex - `app/.*`. All other path/package names that don't match any regexes get sorted into the group labeled `THE_REST`.
+
 ## sortSideEffectsFirst
 -----------------------
 

--- a/src/tests/rules/ordered-imports-by-path.ts
+++ b/src/tests/rules/ordered-imports-by-path.ts
@@ -17,138 +17,330 @@ describe("ordered-imports-by-path ES", () => {
     it("passes and fails appropriately", () => {
         esRuleTester.run("ordered-imports-by-path", orderedImportsByPathRule, {
             valid: [
-                `import Alpha from "Alpha";\n` +
-                    `import Bravo from "Bravo";`,
-                `import Alpha from "Alpha";\n` +
-                    `import { Bravo } from "Bravo";\n` +
-                    `import { Charlie } from "Charlie";\n` +
-                    `import Delta from "Delta";`,
+                `import Alpha from "Alpha001";\n` +
+                    `import Bravo from "Bravo002";`,
+                `import Alpha from "Alpha003";\n` +
+                    `import { Bravo } from "Bravo004";\n` +
+                    `import { Charlie } from "Charlie005";\n` +
+                    `import Delta from "Delta006";`,
                 {
-                    code: `import { Alpha } from "Alpha";\n` +
-                        `import Charlie from "Charlie";\n` +
-                        `import bravo from "bravo";\n`,
+                    code: `import { Alpha } from "Alpha007";\n` +
+                        `import Charlie from "Charlie008";\n` +
+                        `import bravo from "bravo009";\n`,
                     options: [{ignoreCase: false}],
                 }, {
-                    code: `import { Alpha } from "Alpha";\n` +
-                        `import bravo from "bravo";\n` +
-                        `import Charlie from "Charlie";\n`,
+                    code: `import { Alpha } from "Alpha010";\n` +
+                        `import bravo from "bravo011";\n` +
+                        `import Charlie from "Charlie012";\n`,
                     options: [{ignoreCase: true}],
                 }, {
-                    code: `import { Alpha } from "Alpha";\n` +
-                        `import Bravo from "Bravo";\n` +
-                        `import Charlie from "Charlie";\n`,
+                    code: `import { Alpha } from "Alpha013";\n` +
+                        `import Bravo from "Bravo014";\n` +
+                        `import Charlie from "Charlie015";\n`,
                     options: [{allowSeparateGroups: false}],
                 }, {
-                    code: `import { Alpha } from "Alpha";\n` +
-                        `import Bravo from "Bravo";\n` +
-                        `import Charlie from "Charlie";\n\n` +
+                    code: `import { Alpha } from "Alpha016";\n` +
+                        `import Bravo from "Bravo017";\n` +
+                        `import Charlie from "Charlie018";\n\n` +
 
-                        `import Alice from "Alice";\n` +
-                        `import Bob from "Bob";\n`,
+                        `import Alice from "Alice019";\n` +
+                        `import Bob from "Bob020";\n`,
                     options: [{allowSeparateGroups: true}],
                 }, {
-                    code: `import { Alpha } from "Alpha";\n` +
-                        `import Bravo from "Bravo";\n` +
-                        `import "Cool-script";\n` +
-                        `import Delta from "Delta";\n`,
+                    code: `import { Alpha } from "Alpha021";\n` +
+                        `import Bravo from "Bravo022";\n` +
+                        `import "Cool-script023";\n` +
+                        `import Delta from "Delta024";\n`,
                     options: [{sortSideEffectsFirst: false}],
                 }, {
-                    code: `import "Cool-script";\n` +
-                        `import { Alpha } from "Alpha";\n` +
-                        `import Bravo from "Bravo";\n` +
-                        `import Charlie from "Charlie";\n`,
+                    code: `import "Cool-script025";\n` +
+                        `import { Alpha } from "Alpha026";\n` +
+                        `import Bravo from "Bravo027";\n` +
+                        `import Charlie from "Charlie028";\n`,
                     options: [{sortSideEffectsFirst: true}],
+                }, {
+                    code: `import console from "node:console029";\n` +
+                        `import timers from "node:timers030";\n` +
+                        `\n` +
+                        `import WsWebSocket from "ws031";\n` +
+                        `\n` +
+                        `import User from "@app/user032";\n`,
+                    options: [{
+                        groups: [
+                            "node:.*",
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
                 },
-                `import { Alpha, Bravo, Charlie, Delta } from "alphabet";`,
+                `import { Alpha, Bravo, Charlie, Delta } from "alphabet033";`,
                 `import {\n` +
                     `Alpha, // first letter\n` +
                     `Bravo,\n` +
                     `// Charlie,\n` +
-                    `Delta } from "alphabet";`,
-                `import { Alpha, Bravo, /* Charlie, Delta,*/ Echo } from "alphabet";`,
+                    `Delta } from "alphabet034";`,
+                `import { Alpha, Bravo, /* Charlie, Delta,*/ Echo } from "alphabet035";`,
                 `import util, {\n` +
                     `Alpha,\n` +
                     `Bravo,\n` +
                     `/* Charlie,\n` +
                     `Delta,*/\n` +
-                    `Echo } from "alphabet";`,
+                    `Echo } from "alphabet036";`,
                 `import {\n` +
                     `Alpha,\n` +
                     `Bravo,\n` +
                     `/* Charlie,\n` +
                     `Delta,*/\n` +
-                    `Echo } from "alphabet";`,
+                    `Echo } from "alphabet037";`,
                 `import {\n` +
                     `// Alpha,\n` +
                     `Bravo,\n` +
                     `/* Charlie,\n` +
                     `Delta,*/\n` +
-                    `Echo } from "alphabet";`,
+                    `Echo } from "alphabet038";`,
+                {
+                    code: `import fs from "node:fs039";\n` +
+                        `\n` +
+                        `import User from "@app/user040";\n`,
+                    options: [{
+                        groups: [
+                            "node:.*",
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
+                }, {
+                    code: `import "cool-script041";\n` +
+                        `\n` +
+                        `import console from "node:console042";\n` +
+                        `import fs from "node:fs043";\n` +
+                        `\n` +
+                        `import Article from "@app/article044";\n` +
+                        `import User from "@app/user045";`,
+                    options: [{
+                        sortSideEffectsFirst: true,
+                        groups: [
+                            "node:.*",
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
+                }, {
+                    code: `import console from "node:console067";\n` +
+                        `import fs from "node:fs068";\n` +
+                        `\n` +
+                        `import WsWebSocket from "ws069";\n` +
+                        `\n` +
+                        `import User from "@app/user070";\n`,
+                    options: [{
+                        groups: [
+                            "node:.*",
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
+                }, {
+                    code: `import console from "node:console071";\n` +
+                        `import fs from "node:fs072";\n` +
+                        `\n` +
+                        `import WsWebSocket from "ws073";\n` +
+                        `\n` +
+                        `import User from "@app/user074";\n`,
+                    options: [{
+                        groups: [
+                            "node:.*",
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
+                }, {
+                    code: `import { Component } from "@angular/core075";\n` +
+                        `import of from "rxjs077";\n` +
+                        `\n` +
+                        `import User from "@app/user076";\n`,
+                    options: [{
+                        groups: [
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
+                }, {
+                    code: `import { Component } from "@angular/core075";\n` +
+                        `import of from "rxjs077";\n` +
+                        `\n` +
+                        `import User from "@app/user076";\n`,
+                    options: [{
+                        groups: [
+                            "node:.*",
+                            "@someUnusedGroup/.*",
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
+                }, {
+                    code: `import { Component } from "@angular/core078";\n` +
+                        `import of from "rxjs080";\n` +
+                        `\n` +
+                        `import User from "app/user079";\n`,
+                    options: [{
+                        groups: [
+                            "THE_REST",
+                            "app/.*",
+                        ],
+                    }],
+                }, {
+                    code: `import "cool-script081";\n` +
+                        `\n` +
+                        `import console from "node:console082";\n` +
+                        `import fs from "node:fs083";\n` +
+                        `\n` +
+                        `import WsWebSocket from "ws084";\n` +
+                        `\n` +
+                        `import User from "@app/user085";\n`,
+                    options: [{
+                        sortSideEffectsFirst: true,
+                        groups: [
+                            "node:.*",
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
+                }, {
+                    code: `import "cool-script090";\n` +
+                        `\n` +
+                        `import console from "node:console086";\n` +
+                        `import fs from "node:fs087";\n` +
+                        `\n` +
+                        `import WsWebSocket from "ws088";\n` +
+                        `\n` +
+                        `import User from "@app/user089";\n`,
+                    options: [{
+                        sortSideEffectsFirst: true,
+                        groups: [
+                            "node:.*",
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
+                }, {
+                    code: `import "cool-script095";\n` +
+                        `\n` +
+                        `import console from "node:console091";\n` +
+                        `import fs from "node:fs092";\n` +
+                        `\n` +
+                        `import WsWebSocket from "ws093";\n` +
+                        `\n` +
+                        `import User from "@app/user094";\n`,
+                    options: [{
+                        sortSideEffectsFirst: true,
+                        groups: [
+                            "node:.*",
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
+                }, {
+                    code: `import "cool-script098";\n` +
+                        `\n` +
+                        `import console from "node:console096";\n` +
+                        `import fs from "node:fs097";\n` +
+                        `\n` +
+                        `import WsWebSocket from "ws099";\n` +
+                        `\n` +
+                        `import User from "@app/user100";\n`,
+                    options: [{
+                        sortSideEffectsFirst: true,
+                        groups: [
+                            "node:.*",
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
+                }, {
+                    code: `import "@app/side-effects106";\n` +
+                        `import "more-side-effects101";\n` +
+                        `\n` +
+                        `import console from "node:console102";\n` +
+                        `import fs from "node:fs103";\n` +
+                        `\n` +
+                        `import yargs from "yargs104";\n` +
+                        `\n` +
+                        `import Article from "@app/article105";\n` +
+                        `import User from "@app/user107";\n`,
+                    options: [{
+                        sortSideEffectsFirst: true,
+                        groups: [
+                            "node:.*",
+                            "THE_REST",
+                            "@app/.*",
+                        ],
+                    }],
+                },
             ],
             invalid: [{
-                code: `import Bravo from "Bravo";\n` +
-                    `import Alpha from "Alpha";`,
+                code: `import Bravo from "Bravo546";\n` +
+                    `import Alpha from "Alpha547";`,
                 errors: [{
                     messageId: "sortImportsByPath",
                 }],
-                output: `import Alpha from "Alpha";\n` +
-                    `import Bravo from "Bravo";`,
+                output: `import Alpha from "Alpha547";\n` +
+                    `import Bravo from "Bravo546";`,
             }, {
-                code: `import Bravo from "Bravo";\n` +
-                    `import alphaFun from "alphaFun";`,
+                code: `import Bravo from "Bravo548";\n` +
+                    `import alphaFun from "alphaFun549";`,
                 options: [{ignoreCase: true}],
                 errors: [{
                     messageId: "sortImportsByPath",
                 }],
-                output: `import alphaFun from "alphaFun";\n` +
-                    `import Bravo from "Bravo";`,
+                output: `import alphaFun from "alphaFun549";\n` +
+                    `import Bravo from "Bravo548";`,
             }, {
-                code: `import { Alpha } from "Alpha";\n` +
-                    `import Bravo from "Bravo";\n` +
-                    `import Charlie from "Charlie";\n\n` +
+                code: `import { Alpha } from "Alpha556";\n` +
+                    `import Bravo from "Bravo551";\n` +
+                    `import Charlie from "Charlie552";\n\n` +
 
-                    `import Alice from "Alice";\n` +
-                    `import Bob from "Bob";\n`,
+                    `import Alice from "Alice553";\n` +
+                    `import Bob from "Bob554";\n`,
                 options: [{allowSeparateGroups: false}],
                 errors: [{
                     messageId: "sortImportsByPath",
                 }],
-                output: `import Alice from "Alice";\n` +
-                    `import { Alpha } from "Alpha";\n` +
-                    `import Bob from "Bob";\n` +
-                    `import Bravo from "Bravo";\n` +
-                    `import Charlie from "Charlie";\n`,
+                output: `import Alice from "Alice553";\n` +
+                    `import { Alpha } from "Alpha556";\n` +
+                    `import Bob from "Bob554";\n` +
+                    `import Bravo from "Bravo551";\n` +
+                    `import Charlie from "Charlie552";\n`,
             }, {
-                code: `import { Alpha } from "Alpha";\n` +
-                    `import Bravo from "Bravo";\n` +
-                    `import "Cool-script";\n` +
-                    `import Delta from "Delta";\n`,
+                code: `import { Alpha } from "Alpha555";\n` +
+                    `import Bravo from "Bravo556";\n` +
+                    `import "Cool-script557";\n` +
+                    `import Delta from "Delta558";\n`,
                 options: [{sortSideEffectsFirst: true}],
                 errors: [{
                     messageId: "sortSideEffectsFirst",
                 }],
-                output: `import "Cool-script";\n` +
-                    `import { Alpha } from "Alpha";\n` +
-                    `import Bravo from "Bravo";\n` +
-                    `import Delta from "Delta";\n`,
+                output: `import "Cool-script557";\n` +
+                    `import { Alpha } from "Alpha555";\n` +
+                    `import Bravo from "Bravo556";\n` +
+                    `import Delta from "Delta558";\n`,
             }, {
-                code: `import "Cool-script";\n` +
-                    `import { Alpha } from "Alpha";\n` +
-                    `import Bravo from "Bravo";\n` +
-                    `import Delta from "Delta";\n`,
+                code: `import "Cool-script559";\n` +
+                    `import { Alpha } from "Alpha560";\n` +
+                    `import Bravo from "Bravo561";\n` +
+                    `import Delta from "Delta562";\n`,
                 options: [{sortSideEffectsFirst: false}],
                 errors: [{
                     messageId: "sortImportsByPath",
                 }],
-                output: `import { Alpha } from "Alpha";\n` +
-                    `import Bravo from "Bravo";\n` +
-                    `import "Cool-script";\n` +
-                    `import Delta from "Delta";\n`,
+                output: `import { Alpha } from "Alpha560";\n` +
+                    `import Bravo from "Bravo561";\n` +
+                    `import "Cool-script559";\n` +
+                    `import Delta from "Delta562";\n`,
             }, {
-                code: `import BinarySearch from "app/algorithms/binary-search";\n` +
-                    `import OrderedPair from "app/common/ordered-pair";\n` +
-                    `import Monolith from "app/models/monolith";\n` +
-                    `import Direction from "app/direction";\n\n` +
+                code: `import BinarySearch from "app/algorithms/binary-search563";\n` +
+                    `import OrderedPair from "app/common/ordered-pair564";\n` +
+                    `import Monolith from "app/models/monolith565";\n` +
+                    `import Direction from "app/direction566";\n\n` +
 
                     `/**\n` +
                     ` * This is a very informative and thorough piece of documentation\n` +
@@ -157,15 +349,276 @@ describe("ordered-imports-by-path ES", () => {
                 errors: [{
                     messageId: "sortImportsByPath",
                 }],
-                output: `import BinarySearch from "app/algorithms/binary-search";\n` +
-                    `import OrderedPair from "app/common/ordered-pair";\n` +
-                    `import Direction from "app/direction";\n` +
-                    `import Monolith from "app/models/monolith";\n\n` +
+                output: `import BinarySearch from "app/algorithms/binary-search563";\n` +
+                    `import OrderedPair from "app/common/ordered-pair564";\n` +
+                    `import Direction from "app/direction566";\n` +
+                    `import Monolith from "app/models/monolith565";\n\n` +
 
                     `/**\n` +
                     ` * This is a very informative and thorough piece of documentation\n` +
                     ` */\n` +
                     `class Application {}`,
+            }, {
+                code: `import console from "node:console567";\n` +
+                    `import fs from "node:fs568";\n` +
+                    `import WsWebSocket from "ws569";\n` +
+                    `import User from "@app/user570";\n`,
+                options: [{
+                    groups: [
+                        "node:.*",
+                        "THE_REST",
+                        "@app/.*",
+                    ],
+                }],
+                errors: [{
+                    message: "ws569 should be in group `THE_REST` (#1) but is in group `node:.*` (#0)",
+                }, {
+                    message: "@app/user570 should be in group `@app/.*` (#2) but is in group `node:.*` (#0)",
+                }, {
+                    message: "Sort imports alphabetically by path. `@app/user570` should come before `ws569`",
+                }],
+                output: `import console from "node:console567";\n` +
+                    `import fs from "node:fs568";\n` +
+                    `\n` +
+                    `import WsWebSocket from "ws569";\n` +
+                    `\n` +
+                    `import User from "@app/user570";\n`,
+            }, {
+                code: `import console from "node:console571";\n` +
+                    `import fs from "node:fs572";\n` +
+                    `\n` +
+                    `import WsWebSocket from "ws573";\n` +
+                    `import User from "@app/user574";\n`,
+                options: [{
+                    groups: [
+                        "node:.*",
+                        "THE_REST",
+                        "@app/.*",
+                    ],
+                }],
+                errors: [{
+                    message: "@app/user574 should be in group `@app/.*` (#2) but is in group `THE_REST` (#1)",
+                }, {
+                    message: "Sort imports alphabetically by path. `@app/user574` should come before `ws573`",
+                }],
+                output: `import console from "node:console571";\n` +
+                    `import fs from "node:fs572";\n` +
+                    `\n` +
+                    `import WsWebSocket from "ws573";\n` +
+                    `\n` +
+                    `import User from "@app/user574";\n`,
+            }, {
+                code: `import { Component } from "@angular/core575";\n` +
+                    `import User from "@app/user576";\n` +
+                    `import of from "rxjs577";\n`,
+                options: [{
+                    groups: [
+                        "THE_REST",
+                        "@app/.*",
+                    ],
+                }],
+                errors: [{
+                    message: "@app/user576 should be in group `@app/.*` (#1) but is in group `THE_REST` (#0)",
+                }],
+                output: `import { Component } from "@angular/core575";\n` +
+                    `import of from "rxjs577";\n` +
+                    `\n` +
+                    `import User from "@app/user576";\n`,
+            }, {
+                code: `import { Component } from "@angular/core578";\n` +
+                    `\n` +
+                    `import User from "app/user579";\n` +
+                    `\n` +
+                    `import of from "rxjs580";\n`,
+                options: [{
+                    groups: [
+                        "THE_REST",
+                        "app/.*",
+                    ],
+                }],
+                errors: [{
+                    message: "rxjs580 should be in group `THE_REST` (#0) but is in group `<out of bounds>` (#2)",
+                }],
+                output: `import { Component } from "@angular/core578";\n` +
+                    `import of from "rxjs580";\n` +
+                    `\n` +
+                    `import User from "app/user579";\n`,
+            }, {
+                code: `import "cool-script581";\n` +
+                    `import console from "node:console582";\n` +
+                    `import fs from "node:fs583";\n` +
+                    `import WsWebSocket from "ws584";\n` +
+                    `import User from "@app/user585";\n`,
+                options: [{
+                    sortSideEffectsFirst: true,
+                    groups: [
+                        "node:.*",
+                        "THE_REST",
+                        "@app/.*",
+                    ],
+                }],
+                errors: [{
+                    message: "node:console582 should be in group `node:.*` (#1) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "node:fs583 should be in group `node:.*` (#1) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "ws584 should be in group `THE_REST` (#2) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "@app/user585 should be in group `@app/.*` (#3) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "Sort imports alphabetically by path. `@app/user585` should come before `ws584`",
+                }],
+                output: `import "cool-script581";\n` +
+                    `\n` +
+                    `import console from "node:console582";\n` +
+                    `import fs from "node:fs583";\n` +
+                    `\n` +
+                    `import WsWebSocket from "ws584";\n` +
+                    `\n` +
+                    `import User from "@app/user585";\n`,
+            }, {
+                code:
+                    `import console from "node:console586";\n` +
+                    `import fs from "node:fs587";\n` +
+                    `import WsWebSocket from "ws588";\n` +
+                    `import User from "@app/user589";\n` +
+                    `import "cool-script590";\n`,
+                options: [{
+                    sortSideEffectsFirst: true,
+                    groups: [
+                        "node:.*",
+                        "THE_REST",
+                        "@app/.*",
+                    ],
+                }],
+                errors: [{
+                    message: "node:console586 should be in group `node:.*` (#1) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "node:fs587 should be in group `node:.*` (#1) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "ws588 should be in group `THE_REST` (#2) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "@app/user589 should be in group `@app/.*` (#3) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "Sort imports alphabetically by path. `@app/user589` should come before `ws588`",
+                }, {
+                    messageId: "sortSideEffectsFirst",
+                }],
+                output: `import "cool-script590";\n` +
+                    `\n` +
+                    `import console from "node:console586";\n` +
+                    `import fs from "node:fs587";\n` +
+                    `\n` +
+                    `import WsWebSocket from "ws588";\n` +
+                    `\n` +
+                    `import User from "@app/user589";\n`,
+            }, {
+                code:
+                    `import console from "node:console591";\n` +
+                    `import fs from "node:fs592";\n` +
+                    `import WsWebSocket from "ws593";\n` +
+                    `import User from "@app/user594";\n` +
+                    `\n` +
+                    `import "cool-script595";\n`,
+                options: [{
+                    sortSideEffectsFirst: true,
+                    groups: [
+                        "node:.*",
+                        "THE_REST",
+                        "@app/.*",
+                    ],
+                }],
+                errors: [{
+                    message: "node:console591 should be in group `node:.*` (#1) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "node:fs592 should be in group `node:.*` (#1) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "ws593 should be in group `THE_REST` (#2) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "@app/user594 should be in group `@app/.*` (#3) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "Sort imports alphabetically by path. `@app/user594` should come before `ws593`",
+                }, {
+                    message: "cool-script595 should be in group `SIDE_EFFECTS` (#0) but is in group `node:.*` (#1)",
+                }],
+                output: `import "cool-script595";\n` +
+                    `\n` +
+                    `import console from "node:console591";\n` +
+                    `import fs from "node:fs592";\n` +
+                    `\n` +
+                    `import WsWebSocket from "ws593";\n` +
+                    `\n` +
+                    `import User from "@app/user594";\n`,
+            }, {
+                code:
+                    `import console from "node:console596";\n` +
+                    `import fs from "node:fs597";\n` +
+                    `\n` +
+                    `import "cool-script598";\n` +
+                    `\n` +
+                    `import WsWebSocket from "ws599";\n` +
+                    `import User from "@app/user600";\n`,
+                options: [{
+                    sortSideEffectsFirst: true,
+                    groups: [
+                        "node:.*",
+                        "THE_REST",
+                        "@app/.*",
+                    ],
+                }],
+                errors: [{
+                    message: "node:console596 should be in group `node:.*` (#1) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "node:fs597 should be in group `node:.*` (#1) but is in group `SIDE_EFFECTS` (#0)",
+                }, {
+                    message: "cool-script598 should be in group `SIDE_EFFECTS` (#0) but is in group `node:.*` (#1)",
+                }, {
+                    message: "@app/user600 should be in group `@app/.*` (#3) but is in group `THE_REST` (#2)",
+                }, {
+                    message: "Sort imports alphabetically by path. `@app/user600` should come before `ws599`",
+                }],
+                output: `import "cool-script598";\n` +
+                    `\n` +
+                    `import console from "node:console596";\n` +
+                    `import fs from "node:fs597";\n` +
+                    `\n` +
+                    `import WsWebSocket from "ws599";\n` +
+                    `\n` +
+                    `import User from "@app/user600";\n`,
+            }, {
+                code: `import "more-side-effects601";\n` +
+                    `\n` +
+                    `import console from "node:console602";\n` +
+                    `import fs from "node:fs603";\n` +
+                    `\n` +
+                    `import yargs from "yargs604";\n` +
+                    `\n` +
+                    `import Article from "@app/article605";\n` +
+                    `import "@app/side-effects606";\n` +
+                    `import User from "@app/user607";\n`,
+                options: [{
+                    sortSideEffectsFirst: true,
+                    groups: [
+                        "node:.*",
+                        "THE_REST",
+                        "@app/.*",
+                    ],
+                }],
+                errors: [{
+                    message: "@app/side-effects606 should be in group `SIDE_EFFECTS` (#0) but is in group `@app/.*` (#3)",
+                }, {
+                    message: "Sort side-effects-only modules before others. `import \"@app/side-effects606\";` should come before `import Article from \"@app/article605\";`",
+                }],
+                output: `import "@app/side-effects606";\n` +
+                    `import "more-side-effects601";\n` +
+                    `\n` +
+                    `import console from "node:console602";\n` +
+                    `import fs from "node:fs603";\n` +
+                    `\n` +
+                    `import yargs from "yargs604";\n` +
+                    `\n` +
+                    `import Article from "@app/article605";\n` +
+                    `import User from "@app/user607";\n`,
             }],
         });
     });
@@ -181,37 +634,37 @@ describe("ordered-imports-by-path TS", () => {
     it("passes and fails appropriately", () => {
         tsRuleTester.run("ordered-imports-by-path", orderedImportsByPathRule, {
             valid: [{
-                code: `import { ArrayList } from "Collections";\n` +
-                    `import type { List } from "Collections";\n`,
+                code: `import { ArrayList } from "Collections901";\n` +
+                    `import type { List } from "Collections901";\n`,
                 options: [{sortTypeImportsFirst: false}],
             }, {
-                code: `import type { List } from "Collections";\n` +
-                    `import { ArrayList } from "Collections";\n`,
+                code: `import type { List } from "Collections902";\n` +
+                    `import { ArrayList } from "Collections902";\n`,
                 options: [{sortTypeImportsFirst: true}],
             },
-            `import { ArrayList } from "Collections";\n` +
-                `import type { List } from "Collections";\n`,
-            `import type { List } from "Collections";\n` +
-                `import { ArrayList } from "Collections";\n`,
+            `import { ArrayList } from "Collections903";\n` +
+                `import type { List } from "Collections903";\n`,
+            `import type { List } from "Collections904";\n` +
+                `import { ArrayList } from "Collections904";\n`,
             ],
             invalid: [{
-                code: `import type { List } from "Collections";\n` +
-                    `import { ArrayList } from "Collections";\n`,
+                code: `import type { List } from "Collections905";\n` +
+                    `import { ArrayList } from "Collections905";\n`,
                 options: [{sortTypeImportsFirst: false}],
                 errors: [{
                     messageId: "sortTypeImports",
                 }],
-                output: `import { ArrayList } from "Collections";\n` +
-                    `import type { List } from "Collections";\n`,
+                output: `import { ArrayList } from "Collections905";\n` +
+                    `import type { List } from "Collections905";\n`,
             }, {
-                code: `import { ArrayList } from "Collections";\n` +
-                    `import type { List } from "Collections";\n`,
+                code: `import { ArrayList } from "Collections906";\n` +
+                    `import type { List } from "Collections906";\n`,
                 options: [{sortTypeImportsFirst: true}],
                 errors: [{
                     messageId: "sortTypeImports",
                 }],
-                output: `import type { List } from "Collections";\n` +
-                    `import { ArrayList } from "Collections";\n`,
+                output: `import type { List } from "Collections906";\n` +
+                    `import { ArrayList } from "Collections906";\n`,
             }],
         });
     });


### PR DESCRIPTION
`groups` allows users to specify which line-break-separated group imports should be sorted into.